### PR TITLE
Improve the molecular representation

### DIFF
--- a/notebooks/0.02-seal-ecfp-distance-exploration.py
+++ b/notebooks/0.02-seal-ecfp-distance-exploration.py
@@ -43,7 +43,7 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
             fps.append(None)
             failed += 1
         else:
-            fps.append(AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits))
+            fps.append(AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits, useChirality=True))
     if failed > 0:
         logger.warning(f"{failed} SMILES failed to parse")
     return fps
@@ -97,7 +97,7 @@ def main(
     df = pd.concat([train, test], ignore_index=True)
     logger.info(f"Combined: {len(df)} molecules")
 
-    logger.info("Computing ECFP4 fingerprints (2048-bit, radius 2)")
+    logger.info("Computing ECFP4 fingerprints (2048-bit, radius 2, chirality-aware)")
     fps = compute_ecfp4(df["SMILES"].tolist())
 
     # Filter out failed parses

--- a/notebooks/2.07-seal-performance-distance.py
+++ b/notebooks/2.07-seal-performance-distance.py
@@ -102,7 +102,7 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
         if mol is None:
             fps.append(np.zeros(nbits, dtype=np.uint8))
         else:
-            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits)
+            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits, useChirality=True)
             fps.append(np.array(fp, dtype=np.uint8))
     return np.vstack(fps)
 

--- a/notebooks/2.08-seal-baseline-performance.py
+++ b/notebooks/2.08-seal-baseline-performance.py
@@ -101,7 +101,7 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
         if mol is None:
             fps.append(np.zeros(nbits, dtype=np.uint8))
         else:
-            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits)
+            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits, useChirality=True)
             fps.append(np.array(fp, dtype=np.uint8))
     return np.vstack(fps)
 

--- a/notebooks/2.09-seal-iid-vs-ood-series.py
+++ b/notebooks/2.09-seal-iid-vs-ood-series.py
@@ -97,7 +97,7 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
         if mol is None:
             fps.append(np.zeros(nbits, dtype=np.uint8))
         else:
-            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits)
+            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits, useChirality=True)
             fps.append(np.array(fp, dtype=np.uint8))
     return np.vstack(fps)
 

--- a/notebooks/2.10-seal-activity-cliff-eval.py
+++ b/notebooks/2.10-seal-activity-cliff-eval.py
@@ -97,7 +97,7 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
         if mol is None:
             fps.append(np.zeros(nbits, dtype=np.uint8))
         else:
-            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits)
+            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits, useChirality=True)
             fps.append(np.array(fp, dtype=np.uint8))
     return np.vstack(fps)
 

--- a/notebooks/2.11-seal-scaffold-vs-random.py
+++ b/notebooks/2.11-seal-scaffold-vs-random.py
@@ -94,7 +94,7 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
         if mol is None:
             fps.append(np.zeros(nbits, dtype=np.uint8))
         else:
-            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits)
+            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits, useChirality=True)
             fps.append(np.array(fp, dtype=np.uint8))
     return np.vstack(fps)
 

--- a/notebooks/2.13-seal-molecular-variants.py
+++ b/notebooks/2.13-seal-molecular-variants.py
@@ -101,7 +101,7 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
         if mol is None:
             fps.append(np.zeros(nbits, dtype=np.uint8))
         else:
-            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits)
+            fp = AllChem.GetMorganFingerprintAsBitVect(mol, radius, nBits=nbits, useChirality=True)
             fps.append(np.array(fp, dtype=np.uint8))
     return np.vstack(fps)
 


### PR DESCRIPTION
I am making this PR to finalize the decisions about the final molecular representation.
Since the dataset does have chiral compounds, the ECFP4 computation has been modified to use `useChirality=True`

Suggestions:

1. Remove redundant feature computations. Create the fingerprint+descriptors for the relevant datasets and cache them for use in different analyses. This will also help keep the code clean where the representation needs to be updated in a single place.
2. There is empirical evidence that using count-based instead of bit-based Morgan fingerprints is more useful for ADMET tasks. While not the main focus of the paper, we can update this to be more in line with industry-relevant baseline.