### PR TITLE
Adding chemprop modeling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,25 +15,31 @@ pixi install
 # Download dataset from HuggingFace (also runs automatically on cheminformatics env activation)
 pixi run download
 
-# Run Python
+# Run Python (default env)
 pixi run python
+
+# Run an analysis notebook (cheminformatics env required for RDKit, Chemprop, PyArrow)
+pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py
+pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --model chemprop
+pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --combined
 ```
 
 ### Adding Dependencies
 
 - Add Python packages to `[project] dependencies` in `pyproject.toml`, not `[tool.pixi.dependencies]` (which is for conda packages)
+- RDKit, PyArrow, and Chemprop are conda-only; they go in `[tool.pixi.feature.cheminformatics.dependencies]`
 
 ### Code Quality
 
 ```bash
 # Run linter (ruff)
-pixi run ruff check src/polaris_generalization
+pixi run -e lint ruff check src/polaris_generalization
 
 # Run formatter
-pixi run ruff format src/polaris_generalization
+pixi run -e lint ruff format src/polaris_generalization
 
 # Run tests
-pixi run pytest
+pixi run -e test pytest
 ```
 
 ## Architecture
@@ -42,22 +48,35 @@ This is a generalization evaluation framework for molecular ML, analyzing how mo
 
 ### Key Components
 
-1. **Source Package** (`src/polaris_generalization/`): Modules for:
+1. **Source Package** (`src/polaris_generalization/`): Shared modules:
    - `config.py`: Centralized path definitions using pathlib
-   - `visualization.py`: Shared plotting utilities
-   - Future modules: dataset_analysis, splitting, distance_metrics, evaluation
+   - `visualization.py`: Plotting utilities — `set_style()`, `DEFAULT_DPI`, `MODEL_COLORS`, `MODEL_LABELS`, `plot_model_comparison_bars()`
+   - `tuning.py`: Optuna TPE XGBoost hyperparameter tuning with JSON caching (`tune_xgboost`)
+   - `chemprop_utils.py`: Chemprop D-MPNN training with prediction caching (`train_chemprop`)
 
 2. **Notebooks** (`notebooks/`): Analysis notebooks following phase-based naming
    - Convention: `<phase>.<sequence>-<initials>-<description>.py`
    - Phases: 0 = exploration, 1 = data loading, 2 = analysis, 3 = figures
+   - All modeling notebooks support `--model xgboost|chemprop` and `--combined` flags
 
 3. **Data Organization** (cookiecutter data science):
-   - `data/external/`: External datasets (Expansion Tx ADMET data)
+   - `data/external/`: External datasets
    - `data/raw/`: Original immutable data
-   - `data/interim/`: Intermediate transformed data
-   - `data/processed/`: Final analysis outputs
+   - `data/interim/`: Intermediate data — CV folds, Tanimoto matrix, `optuna_cache/`, `chemprop_pred_cache/`
+   - `data/processed/`: Analysis outputs, organized as `{notebook}/{model}/` with a `combined/` subdirectory
 
 4. **Configuration** (`configs/`): Model and experiment configuration files
+
+### Modeling: XGBoost vs Chemprop
+
+Every modeling notebook (2.07–2.15) supports two model backends:
+
+- **XGBoost** (`--model xgboost`, default): ECFP4 (2048-bit) + ~200 RDKit 2D descriptors, Optuna TPE-tuned per endpoint. Hyperparameters cached as JSON in `data/interim/optuna_cache/`.
+- **Chemprop** (`--model chemprop`): D-MPNN trained directly on protonated SMILES, default hyperparameters (hidden_dim=300, depth=3, 50 epochs). Predictions cached as `.npy` in `data/interim/chemprop_pred_cache/`.
+
+Both models use dimorphite_dl protonation at assay-relevant pH before training. Log-transform protocol (`log10(clip(x, 1e-10) + 1)`) applies to all endpoints except LogD for both models.
+
+Outputs go to `data/processed/{notebook}/{model}/` with shared figure helpers in `visualization.py`. Running `--combined` generates side-by-side comparison figures in `data/processed/{notebook}/combined/`.
 
 ### Dataset
 
@@ -91,9 +110,13 @@ Download: `pixi run download` (also auto-runs on cheminformatics env activation)
 
 ## Quick Reference
 
-- `docs/paper/`: Paper outline, analysis checklist, and planning documents
+- `docs/paper/`: Paper outline and analysis checklist (source of truth for analysis status)
 - `docs/decisions/`: Decision records for significant technical choices
 - `scripts/`: Shell scripts and pipeline orchestration
-- `notebooks/`: All Python analysis (use phase 0: `0.xx-seal-description.py` for exploration)
+- `notebooks/`: All Python analysis
+  - Phase 0: exploration (`0.01`, `0.02`, `0.03`)
+  - Phase 1: data loading (`1.01`)
+  - Phase 2: analysis (`2.01`–`2.16`)
+  - Phase 3: figures (`3.02`)
 - Always use the typer library for argument parsing
-- When running python, always use `pixi run python`
+- When running python, always use `pixi run -e cheminformatics python` for any notebook

--- a/notebooks/2.07-seal-performance-distance.py
+++ b/notebooks/2.07-seal-performance-distance.py
@@ -1,24 +1,31 @@
 #!/usr/bin/env python
 """Performance-over-distance curves for all endpoints across all split strategies.
 
-Trains XGBoost on ECFP4 + full RDKit 2D descriptors (~200) using pre-saved CV
-folds (cluster, time, target — repeat 0), then plots how RMSE degrades with
-distance from training data. Molecules are protonated at assay-relevant pH
-using dimorphite_dl before feature computation. For endpoints not already on
-log scale (everything except LogD), targets are log-transformed for both
-training and evaluation, matching the OpenADMET competition protocol.
+Trains a model (XGBoost or Chemprop D-MPNN) on pre-saved CV folds (cluster, time,
+target — repeat 0), then plots how RMSE degrades with distance from training data.
+Molecules are protonated at assay-relevant pH using dimorphite_dl before feature
+computation. For endpoints not already on log scale (everything except LogD),
+targets are log-transformed for both training and evaluation, matching the
+OpenADMET competition protocol.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.07-seal-performance-distance.py
+    pixi run -e cheminformatics python notebooks/2.07-seal-performance-distance.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.07-seal-performance-distance.py --combined
 
-Outputs:
-    data/processed/2.07-seal-performance-distance/overall_r2.png
-    data/processed/2.07-seal-performance-distance/overall_rmse.png
-    data/processed/2.07-seal-performance-distance/per_fold_performance.csv
-    data/processed/2.07-seal-performance-distance/performance_over_distance.png
-    data/processed/2.07-seal-performance-distance/performance_over_target_distance.png
-    data/processed/2.07-seal-performance-distance/performance_distance_summary.csv
-    data/processed/2.07-seal-performance-distance/predictions.parquet
+Outputs (under data/processed/2.07-seal-performance-distance/{model}/):
+    predictions.parquet
+    per_fold_performance.csv
+    performance_distance_summary.csv
+    overall_mae.png, overall_r2.png, overall_rae.png, overall_spearman_r.png
+    performance_over_distance.png
+    performance_over_target_distance.png
+    performance_over_distance_v2.png
+
+Combined outputs (under …/combined/):
+    performance_over_distance_combined.png
+    performance_over_target_distance_combined.png
+    metrics_comparison.csv
 """
 
 from pathlib import Path
@@ -38,9 +45,15 @@ from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    MODEL_LABELS,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -72,18 +85,15 @@ STRATEGIES = {
     "target": {"file": "target_cv_folds.parquet", "n_folds": 4},
 }
 
-# Full RDKit 2D descriptor suite
 DESCRIPTOR_NAMES = [name for name, _ in Descriptors.descList]
 DESC_CALC = MolecularDescriptorCalculator(DESCRIPTOR_NAMES)
 
 
 def clip_and_log_transform(x: np.ndarray) -> np.ndarray:
-    """Log-transform matching competition evaluation: log10(clip(x, 1e-10) + 1)."""
     return np.log10(np.clip(x, 1e-10, None) + 1)
 
 
 def protonate_at_ph(smiles_list: list[str], ph: float) -> list[str]:
-    """Protonate SMILES at given pH using dimorphite_dl."""
     protonated = []
     for smi in smiles_list:
         try:
@@ -95,7 +105,6 @@ def protonate_at_ph(smiles_list: list[str], ph: float) -> list[str]:
 
 
 def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) -> np.ndarray:
-    """Compute ECFP4 fingerprints and return as dense numpy array."""
     fps = []
     for smi in smiles_list:
         mol = Chem.MolFromSmiles(smi)
@@ -108,7 +117,6 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
 
 
 def compute_rdkit_descriptors(smiles_list: list[str]) -> np.ndarray:
-    """Compute full RDKit 2D descriptor suite (~200 descriptors)."""
     rows = []
     for smi in smiles_list:
         mol = Chem.MolFromSmiles(smi)
@@ -122,12 +130,10 @@ def compute_rdkit_descriptors(smiles_list: list[str]) -> np.ndarray:
 
 
 def get_train_test_masks(fold_ids: np.ndarray, fold_id: int, strategy: str) -> tuple[np.ndarray, np.ndarray]:
-    """Get train and test boolean masks for a given fold."""
     test_mask = fold_ids == fold_id
     if strategy == "cluster":
         train_mask = (fold_ids != fold_id) & (fold_ids >= 0)
     else:
-        # Expanding window: train = all folds before test
         train_mask = np.zeros(len(fold_ids), dtype=bool)
         for k in range(-1, fold_id):
             train_mask |= fold_ids == k
@@ -135,7 +141,6 @@ def get_train_test_masks(fold_ids: np.ndarray, fold_id: int, strategy: str) -> t
 
 
 def make_sliding_bins(distances: np.ndarray) -> list[tuple[float, float]]:
-    """Create sliding window bins from pooled distances per outline protocol."""
     q1, q3 = np.percentile(distances, [25, 75])
     iqr = q3 - q1
     d_min = max(0, q1 - 1.5 * iqr)
@@ -156,7 +161,6 @@ def make_sliding_bins(distances: np.ndarray) -> list[tuple[float, float]]:
 
 def bin_performance(distances: np.ndarray, errors_sq: np.ndarray,
                     bins: list[tuple[float, float]], min_count: int = 25) -> dict:
-    """Compute RMSE per bin. Returns dict of bin_center -> rmse (or NaN)."""
     results = {}
     for lo, hi in bins:
         mask = (distances >= lo) & (distances < hi)
@@ -168,33 +172,214 @@ def bin_performance(distances: np.ndarray, errors_sq: np.ndarray,
     return results
 
 
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move pre-refactor flat XGBoost outputs into xgboost/ subdir."""
+    xgb_dir = output_dir / "xgboost"
+    if (output_dir / "predictions.parquet").exists() and not (xgb_dir / "predictions.parquet").exists():
+        xgb_dir.mkdir(parents=True, exist_ok=True)
+        flat_files = [
+            "predictions.parquet",
+            "per_fold_performance.csv",
+            "performance_distance_summary.csv",
+            "overall_mae.png",
+            "overall_r2.png",
+            "overall_rae.png",
+            "overall_spearman_r.png",
+            "performance_over_distance.png",
+            "performance_over_target_distance.png",
+            "performance_over_distance_v2.png",
+        ]
+        for fname in flat_files:
+            src = output_dir / fname
+            if src.exists():
+                src.rename(xgb_dir / fname)
+        logger.info("Migrated flat XGBoost outputs → xgboost/")
 
 
-def plot_performance_over_distance(pred_df: pd.DataFrame, output_dir: Path, dpi: int) -> pd.DataFrame:
-    """Plot performance-over-distance curves from predictions dataframe.
-
-    Returns summary dataframe with per-endpoint degradation ratios and Spearman ρ.
-    """
+def _generate_figures(
+    all_results: list[dict],
+    perf_df: pd.DataFrame,
+    pred_df: pd.DataFrame,
+    model_dir: Path,
+    model: str,
+    dpi: int,
+) -> None:
+    """Save all per-model figures to model_dir."""
     strat_colors = {"cluster": "steelblue", "time": "coral", "target": "forestgreen"}
-    active_endpoints = sorted(pred_df["endpoint"].unique())
+    model_label = MODEL_LABELS.get(model, model)
+    active_endpoints = sorted(perf_df["endpoint"].unique())
     n_ep = len(active_endpoints)
-    ncols = 2
-    nrows = (n_ep + ncols - 1) // ncols
 
+    # ── Bar charts: mae, spearman_r, rae ────────────────────────────────
+    for metric, ylabel in [("mae", "MAE"), ("spearman_r", "Spearman ρ"), ("rae", "RAE")]:
+        fig, ax = plt.subplots(figsize=(14, 6))
+        x = np.arange(n_ep)
+        width = 0.25
+        for i, strat_name in enumerate(STRATEGIES):
+            strat_sub = perf_df[perf_df["strategy"] == strat_name]
+            means, stds = [], []
+            for ep in active_endpoints:
+                ep_vals = strat_sub[strat_sub["endpoint"] == ep][metric]
+                means.append(ep_vals.mean())
+                stds.append(ep_vals.std())
+            ax.bar(x + i * width, means, width, yerr=stds, label=strat_name,
+                   color=strat_colors[strat_name], edgecolor="white", capsize=3, alpha=0.8)
+        ax.set_xticks(x + width)
+        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
+        ax.set_ylabel(ylabel)
+        ax.set_title(f"{ylabel} by endpoint and split strategy — {model_label}")
+        ax.legend(fontsize=8)
+        if metric == "rae":
+            ax.axhline(y=1, color="gray", linestyle="--", alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(model_dir / f"overall_{metric}.png", dpi=dpi, bbox_inches="tight")
+        plt.close("all")
+    logger.info("Saved overall bar charts")
+
+    # ── R² split plot ────────────────────────────────────────────────────
+    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(18, 6), gridspec_kw={"width_ratios": [2, 1]})
+    x = np.arange(n_ep)
+    width = 0.35
+    for i, strat_name in enumerate(["cluster", "time"]):
+        strat_sub = perf_df[perf_df["strategy"] == strat_name]
+        means, stds = [], []
+        for ep in active_endpoints:
+            ep_vals = strat_sub[strat_sub["endpoint"] == ep]["r2"]
+            means.append(ep_vals.mean())
+            stds.append(ep_vals.std())
+        ax1.bar(x + i * width, means, width, yerr=stds, label=strat_name,
+                color=strat_colors[strat_name], edgecolor="white", capsize=3, alpha=0.8)
+    ax1.set_xticks(x + width / 2)
+    ax1.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
+    ax1.set_ylabel("R²")
+    ax1.set_title("R² — Cluster & Time splits")
+    ax1.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
+    ax1.legend(fontsize=8)
+
+    target_sub = perf_df[perf_df["strategy"] == "target"]
+    target_means = [target_sub[target_sub["endpoint"] == ep]["r2"].mean() for ep in active_endpoints]
+    ax2.barh(np.arange(n_ep), target_means, color=strat_colors["target"], alpha=0.8)
+    ax2.set_yticks(np.arange(n_ep))
+    ax2.set_yticklabels(active_endpoints, fontsize=8)
+    ax2.set_xlabel("R²")
+    ax2.set_title("R² — Target split (note scale)")
+    ax2.axvline(x=0, color="gray", linestyle="--", alpha=0.3)
+
+    fig.suptitle(f"R² by endpoint and split strategy — {model_label}", fontsize=14, y=1.02)
+    fig.tight_layout()
+    fig.savefig(model_dir / "overall_r2.png", dpi=dpi, bbox_inches="tight")
+    plt.close("all")
+    logger.info("Saved overall_r2.png")
+
+    # ── Performance over structural distance ─────────────────────────────
+    nrows = (n_ep + 2) // 3
+    ncols = min(n_ep, 3)
     summary_rows = []
 
-    plt.rcParams.update({"font.size": 16, "axes.labelsize": 18, "axes.titlesize": 20,
-                         "xtick.labelsize": 14, "ytick.labelsize": 14, "legend.fontsize": 14})
-    fig, axes = plt.subplots(nrows, ncols, figsize=(9 * ncols, 6 * nrows))
+    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 5 * nrows))
     if n_ep == 1:
         axes = np.array([axes])
     axes = axes.flatten()
 
     for ax_idx, ep in enumerate(active_endpoints):
         ax = axes[ax_idx]
-        ep_pred = pred_df[pred_df["endpoint"] == ep]
+        ep_results = [r for r in all_results if r["endpoint"] == ep]
+        all_dists = np.concatenate([r["struct_dist"] for r in ep_results])
+        bins = make_sliding_bins(all_dists)
 
-        # Pool all distances for shared binning
+        for strat_name in STRATEGIES:
+            strat_results = [r for r in ep_results if r["strategy"] == strat_name]
+            if not strat_results:
+                continue
+            fold_curves = [bin_performance(r["struct_dist"], r["sq_errors"], bins) for r in strat_results]
+            centers = sorted(fold_curves[0].keys())
+            values = np.array([[c[center] for center in centers] for c in fold_curves])
+            median_vals = np.nanmedian(values, axis=0)
+            lo_vals = np.nanpercentile(values, 10, axis=0)
+            hi_vals = np.nanpercentile(values, 90, axis=0)
+            valid = ~np.isnan(median_vals)
+            c_arr = np.array(centers)
+            color = strat_colors[strat_name]
+            ax.plot(c_arr[valid], median_vals[valid], color=color, label=strat_name, linewidth=1.5)
+            ax.fill_between(c_arr[valid], lo_vals[valid], hi_vals[valid], color=color, alpha=0.1)
+            valid_medians = median_vals[valid]
+            if len(valid_medians) > 0:
+                summary_rows.append({
+                    "endpoint": ep,
+                    "strategy": strat_name,
+                    "overall_rmse": float(np.median([r["overall_rmse"] for r in strat_results])),
+                    "rmse_closest_bin": float(valid_medians[0]),
+                    "rmse_farthest_bin": float(valid_medians[-1]),
+                    "degradation_ratio": float(valid_medians[-1] / valid_medians[0]) if valid_medians[0] > 0 else np.nan,
+                })
+        ax.set_xlabel("Test-to-train 1-NN distance (Tanimoto)")
+        ax.set_ylabel("RMSE")
+        ax.set_title(ep)
+        ax.legend(fontsize=7)
+
+    for i in range(n_ep, len(axes)):
+        axes[i].set_visible(False)
+    fig.suptitle(f"Performance over structural distance — {model_label}", fontsize=14, y=1.02)
+    fig.tight_layout()
+    fig.savefig(model_dir / "performance_over_distance.png", dpi=dpi, bbox_inches="tight")
+    plt.close("all")
+    logger.info("Saved performance_over_distance.png")
+
+    # ── Performance over target-space distance ───────────────────────────
+    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 5 * nrows))
+    if n_ep == 1:
+        axes = np.array([axes])
+    axes = axes.flatten()
+
+    for ax_idx, ep in enumerate(active_endpoints):
+        ax = axes[ax_idx]
+        ep_results = [r for r in all_results if r["endpoint"] == ep]
+        all_dists = np.concatenate([r["target_dist"] for r in ep_results])
+        bins = make_sliding_bins(all_dists)
+
+        for strat_name in STRATEGIES:
+            strat_results = [r for r in ep_results if r["strategy"] == strat_name]
+            if not strat_results:
+                continue
+            fold_curves = [bin_performance(r["target_dist"], r["sq_errors"], bins) for r in strat_results]
+            centers = sorted(fold_curves[0].keys())
+            values = np.array([[c[center] for center in centers] for c in fold_curves])
+            median_vals = np.nanmedian(values, axis=0)
+            lo_vals = np.nanpercentile(values, 10, axis=0)
+            hi_vals = np.nanpercentile(values, 90, axis=0)
+            valid = ~np.isnan(median_vals)
+            c_arr = np.array(centers)
+            color = strat_colors[strat_name]
+            ax.plot(c_arr[valid], median_vals[valid], color=color, label=strat_name, linewidth=1.5)
+            ax.fill_between(c_arr[valid], lo_vals[valid], hi_vals[valid], color=color, alpha=0.1)
+        ax.set_xlabel("Test-to-train 1-NN distance (target space)")
+        ax.set_ylabel("RMSE")
+        ax.set_title(ep)
+        ax.legend(fontsize=7)
+
+    for i in range(n_ep, len(axes)):
+        axes[i].set_visible(False)
+    fig.suptitle(f"Performance over target-space distance — {model_label}", fontsize=14, y=1.02)
+    fig.tight_layout()
+    fig.savefig(model_dir / "performance_over_target_distance.png", dpi=dpi, bbox_inches="tight")
+    plt.close("all")
+    logger.info("Saved performance_over_target_distance.png")
+
+    # ── High-res v2 distance plot (from pred_df) ─────────────────────────
+    plt.rcParams.update({"font.size": 16, "axes.labelsize": 18, "axes.titlesize": 20,
+                         "xtick.labelsize": 14, "ytick.labelsize": 14, "legend.fontsize": 14})
+    ep_list = sorted(pred_df["endpoint"].unique())
+    n2 = len(ep_list)
+    ncols2 = 2
+    nrows2 = (n2 + ncols2 - 1) // ncols2
+    fig, axes = plt.subplots(nrows2, ncols2, figsize=(9 * ncols2, 6 * nrows2))
+    if n2 == 1:
+        axes = np.array([axes])
+    axes = axes.flatten()
+
+    for ax_idx, ep in enumerate(ep_list):
+        ax = axes[ax_idx]
+        ep_pred = pred_df[pred_df["endpoint"] == ep]
         all_dists = ep_pred["struct_1nn"].values
         bins = make_sliding_bins(all_dists)
 
@@ -202,62 +387,138 @@ def plot_performance_over_distance(pred_df: pd.DataFrame, output_dir: Path, dpi:
             strat_pred = ep_pred[ep_pred["strategy"] == strat_name]
             if strat_pred.empty:
                 continue
-
-            # Per-fold curves
             fold_curves = []
             for fold_id in sorted(strat_pred["fold"].unique()):
                 fold_pred = strat_pred[strat_pred["fold"] == fold_id]
-                dists = fold_pred["struct_1nn"].values
-                sq_errors = (fold_pred["y_pred"] - fold_pred["y_true"]).values ** 2
-                curve = bin_performance(dists, sq_errors, bins)
+                curve = bin_performance(fold_pred["struct_1nn"].values,
+                                        (fold_pred["y_pred"] - fold_pred["y_true"]).values ** 2, bins)
                 fold_curves.append(curve)
-
             centers = sorted(fold_curves[0].keys())
             values = np.array([[c[center] for center in centers] for c in fold_curves])
-
             median_vals = np.nanmedian(values, axis=0)
             lo_vals = np.nanpercentile(values, 10, axis=0)
             hi_vals = np.nanpercentile(values, 90, axis=0)
-
             valid = ~np.isnan(median_vals)
             c_arr = np.array(centers)
-
-            # Spearman ρ (distance vs |error| pooled across folds)
             abs_errors = np.abs(strat_pred["y_pred"] - strat_pred["y_true"]).values
             rho, _ = spearmanr(strat_pred["struct_1nn"].values, abs_errors)
-
             color = strat_colors[strat_name]
             ax.plot(c_arr[valid], median_vals[valid], color=color,
                     label=f"{strat_name} (ρ={rho:.2f})", linewidth=2)
-            ax.fill_between(c_arr[valid], lo_vals[valid], hi_vals[valid],
-                            color=color, alpha=0.1)
-
-            # Summary stats
-            valid_medians = median_vals[valid]
-            if len(valid_medians) > 0:
-                summary_rows.append({
-                    "endpoint": ep,
-                    "strategy": strat_name,
-                    "rmse_closest_bin": float(valid_medians[0]),
-                    "rmse_farthest_bin": float(valid_medians[-1]),
-                    "degradation_ratio": float(valid_medians[-1] / valid_medians[0]) if valid_medians[0] > 0 else np.nan,
-                    "spearman_rho": float(rho),
-                })
-
+            ax.fill_between(c_arr[valid], lo_vals[valid], hi_vals[valid], color=color, alpha=0.1)
         ax.set_xlabel("1-NN Jaccard distance")
         ax.set_ylabel("RMSE")
         ax.set_title(ep, fontweight="bold")
         ax.legend()
 
-    for i in range(n_ep, len(axes)):
+    for i in range(n2, len(axes)):
         axes[i].set_visible(False)
-
     fig.tight_layout()
-    fig.savefig(output_dir / "performance_over_distance_v2.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved performance_over_distance_v2.png")
+    fig.savefig(model_dir / "performance_over_distance_v2.png", dpi=dpi, bbox_inches="tight")
     plt.close("all")
+    logger.info("Saved performance_over_distance_v2.png")
 
-    return pd.DataFrame(summary_rows)
+    # ── Save summary CSV ─────────────────────────────────────────────────
+    pd.DataFrame(summary_rows).to_csv(model_dir / "performance_distance_summary.csv", index=False)
+    logger.info("Saved performance_distance_summary.csv")
+
+    set_style()  # reset rcParams
+
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Overlay XGBoost (solid) and Chemprop (dashed) distance curves on same axes."""
+    combined_dir = output_dir / "combined"
+    combined_dir.mkdir(parents=True, exist_ok=True)
+
+    model_preds = {}
+    for model in ["xgboost", "chemprop"]:
+        pred_file = output_dir / model / "predictions.parquet"
+        if not pred_file.exists():
+            logger.warning(f"Missing {pred_file}; skipping combined figures")
+            return
+        model_preds[model] = pd.read_parquet(pred_file)
+
+    strat_colors = {"cluster": "steelblue", "time": "coral", "target": "forestgreen"}
+    model_linestyles = {"xgboost": "-", "chemprop": "--"}
+    active_endpoints = sorted(model_preds["xgboost"]["endpoint"].unique())
+    n_ep = len(active_endpoints)
+    ncols = 2
+    nrows = (n_ep + ncols - 1) // ncols
+
+    for dist_col, xlabel, fname in [
+        ("struct_1nn", "1-NN Jaccard distance", "performance_over_distance_combined.png"),
+        ("target_1nn", "Test-to-train 1-NN distance (target space)", "performance_over_target_distance_combined.png"),
+    ]:
+        fig, axes = plt.subplots(nrows, ncols, figsize=(9 * ncols, 6 * nrows))
+        if n_ep == 1:
+            axes = np.array([axes])
+        axes = axes.flatten()
+
+        for ax_idx, ep in enumerate(active_endpoints):
+            ax = axes[ax_idx]
+            all_dists = model_preds["xgboost"][model_preds["xgboost"]["endpoint"] == ep][dist_col].values
+            bins = make_sliding_bins(all_dists)
+
+            for model, pred_df in model_preds.items():
+                ep_pred = pred_df[pred_df["endpoint"] == ep]
+                model_label = MODEL_LABELS.get(model, model)
+                ls = model_linestyles[model]
+                for strat_name in ["cluster", "time", "target"]:
+                    strat_pred = ep_pred[ep_pred["strategy"] == strat_name]
+                    if strat_pred.empty:
+                        continue
+                    fold_curves = []
+                    for fold_id in sorted(strat_pred["fold"].unique()):
+                        fold_pred = strat_pred[strat_pred["fold"] == fold_id]
+                        curve = bin_performance(fold_pred[dist_col].values,
+                                                (fold_pred["y_pred"] - fold_pred["y_true"]).values ** 2, bins)
+                        fold_curves.append(curve)
+                    centers = sorted(fold_curves[0].keys())
+                    values = np.array([[c[center] for center in centers] for c in fold_curves])
+                    median_vals = np.nanmedian(values, axis=0)
+                    valid = ~np.isnan(median_vals)
+                    c_arr = np.array(centers)
+                    ax.plot(c_arr[valid], median_vals[valid], color=strat_colors[strat_name],
+                            linestyle=ls, linewidth=1.8,
+                            label=f"{strat_name} ({model_label})")
+
+            ax.set_xlabel(xlabel)
+            ax.set_ylabel("RMSE")
+            ax.set_title(ep, fontweight="bold")
+            ax.legend(fontsize=6)
+
+        for i in range(n_ep, len(axes)):
+            axes[i].set_visible(False)
+        fig.tight_layout()
+        fig.savefig(combined_dir / fname, dpi=dpi, bbox_inches="tight")
+        plt.close("all")
+        logger.info(f"Saved {fname}")
+
+    # ── Degradation-ratio comparison bar chart ───────────────────────────
+    model_metrics = {}
+    for model in ["xgboost", "chemprop"]:
+        summary_file = output_dir / model / "performance_distance_summary.csv"
+        if summary_file.exists():
+            model_metrics[model] = pd.read_csv(summary_file)
+
+    if len(model_metrics) == 2:
+        plot_model_comparison_bars(
+            data_by_model=model_metrics,
+            endpoint_col="endpoint",
+            metric_col="degradation_ratio",
+            ylabel="Degradation ratio (farthest / closest bin RMSE)",
+            title="Structural-distance degradation ratio: XGBoost vs Chemprop",
+            output_path=combined_dir / "degradation_ratio_comparison.png",
+            dpi=dpi,
+        )
+        # Save merged metrics
+        rows = []
+        for model, df in model_metrics.items():
+            df = df.copy()
+            df["model"] = model
+            rows.append(df)
+        pd.concat(rows).to_csv(combined_dir / "metrics_comparison.csv", index=False)
+        logger.info("Saved metrics_comparison.csv")
 
 
 @app.command()
@@ -266,73 +527,78 @@ def main(
         PROCESSED_DATA_DIR / "2.07-seal-performance-distance", help="Output directory"
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
-    figures_only: bool = typer.Option(False, help="Regenerate figures from existing predictions without retraining"),
+    model: str = typer.Option("xgboost", help="Model backend: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
+    _migrate_flat_outputs(output_dir)
 
-    # ── Figures-only mode ─────────────────────────────────────────────
-    if figures_only:
-        logger.info("Figures-only mode: loading existing predictions")
-        pred_df = pd.read_parquet(output_dir / "predictions.parquet")
-        summary_df = plot_performance_over_distance(pred_df, output_dir, dpi)
-        summary_df.to_csv(output_dir / "performance_distance_summary.csv", index=False)
-        logger.info("Figures regenerated (no models retrained)")
+    if combined:
+        logger.info("Generating combined figures")
+        _generate_combined_figures(output_dir, dpi)
         return
 
-    # ── 1. Load data ──────────────────────────────────────────────────
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # Skip if already complete
+    if (model_dir / "predictions.parquet").exists() and (model_dir / "performance_distance_summary.csv").exists():
+        logger.info(f"Found existing outputs for {model}, skipping training")
+        pred_df = pd.read_parquet(model_dir / "predictions.parquet")
+        perf_df = pd.read_csv(model_dir / "per_fold_performance.csv")
+        all_results = []
+        for _, row in pred_df.iterrows():
+            pass
+        _generate_figures(all_results, perf_df, pred_df, model_dir, model, dpi)
+        return
+
+    # ── 1. Load data ──────────────────────────────────────────────────────
     logger.info("Loading data")
     df = pd.read_parquet(INTERIM_DATA_DIR / "expansion_tx.parquet")
     npz = np.load(INTERIM_DATA_DIR / "tanimoto_distance_matrix.npz", allow_pickle=True)
     dist_square = squareform(npz["condensed"])
 
-    # Load all three fold files
     fold_dfs = {}
     for strat_name, strat_info in STRATEGIES.items():
         folds = pd.read_parquet(INTERIM_DATA_DIR / strat_info["file"])
         fold_dfs[strat_name] = folds[folds["repeat"] == 0]
         logger.info(f"  {strat_name}: {len(fold_dfs[strat_name])} rows (repeat=0)")
 
-    # ── 2. Protonate and compute features per pH ─────────────────────
     smiles_list = df["SMILES"].tolist()
     mol_names = df["Molecule Name"].values
 
+    # ── 2. Protonation and features (XGBoost only) ────────────────────────
     unique_phs = sorted(set(ENDPOINT_PH.values()))
     features_by_ph: dict[float, np.ndarray] = {}
+    prot_smiles_by_ph: dict[float, list[str]] = {}
 
     for ph in unique_phs:
         logger.info(f"Protonating at pH {ph}")
         protonated = protonate_at_ph(smiles_list, ph)
+        prot_smiles_by_ph[ph] = protonated
 
-        logger.info(f"Computing features at pH {ph}")
-        ecfp = compute_ecfp4(protonated)
-        desc = compute_rdkit_descriptors(protonated)
+        if model == "xgboost":
+            logger.info(f"Computing features at pH {ph}")
+            ecfp = compute_ecfp4(protonated)
+            desc = compute_rdkit_descriptors(protonated)
+            variance = desc.var(axis=0)
+            desc = desc[:, variance > 0]
+            desc_scaled = StandardScaler().fit_transform(desc)
+            X = np.hstack([ecfp, desc_scaled])
+            logger.info(f"  pH {ph}: {X.shape[1]} features")
+            features_by_ph[ph] = X
 
-        # Remove zero-variance descriptors
-        variance = desc.var(axis=0)
-        nonzero_var = variance > 0
-        desc = desc[:, nonzero_var]
-
-        # Scale descriptors
-        scaler = StandardScaler()
-        desc_scaled = scaler.fit_transform(desc)
-
-        X = np.hstack([ecfp, desc_scaled])
-        logger.info(f"  pH {ph}: {X.shape[1]} features (2048 ECFP + {desc.shape[1]} RDKit 2D)")
-        features_by_ph[ph] = X
-
-    # ── 3. Train models and collect predictions ───────────────────────
+    # ── 3. Train models and collect predictions ───────────────────────────
     all_results = []
     prediction_rows = []
 
-    # Count total iterations
-    total_iters = 0
-    for ep in ENDPOINTS:
-        if df[ep].notna().sum() < 50:
-            continue
-        total_iters += sum(s["n_folds"] for s in STRATEGIES.values())
+    total_iters = sum(
+        s["n_folds"] for ep in ENDPOINTS if df[ep].notna().sum() >= 50 for s in STRATEGIES.values()
+    )
+    pbar = tqdm(total=total_iters, desc=f"Training {model}", unit="fold")
 
-    pbar = tqdm(total=total_iters, desc="Training models", unit="fold")
+    chemprop_cache_dir = INTERIM_DATA_DIR / "chemprop_pred_cache"
 
     for ep in ENDPOINTS:
         mask = df[ep].notna().values
@@ -344,15 +610,14 @@ def main(
         ep_idx = np.where(mask)[0]
         ep_names = mol_names[mask]
         ep_values_raw = df[ep].values[mask]
+        ep_values = clip_and_log_transform(ep_values_raw) if ep in LOG_TRANSFORM_ENDPOINTS else ep_values_raw
 
-        # Log-transform targets (except LogD)
-        if ep in LOG_TRANSFORM_ENDPOINTS:
-            ep_values = clip_and_log_transform(ep_values_raw)
-        else:
-            ep_values = ep_values_raw
-
-        X_ep = features_by_ph[ph][mask]
         D_ep = dist_square[np.ix_(ep_idx, ep_idx)]
+
+        if model == "xgboost":
+            X_ep = features_by_ph[ph][mask]
+        else:
+            ep_prot_smiles = [prot_smiles_by_ph[ph][i] for i in ep_idx]
 
         for strat_name, strat_info in STRATEGIES.items():
             strat_folds = fold_dfs[strat_name]
@@ -362,31 +627,37 @@ def main(
             n_folds = strat_info["n_folds"]
 
             for fold_id in range(n_folds):
-                train_mask, test_mask = get_train_test_masks(fold_ids, fold_id, strat_name)
-
-                test_idx = np.where(test_mask)[0]
-                train_idx = np.where(train_mask)[0]
+                train_mask_f, test_mask_f = get_train_test_masks(fold_ids, fold_id, strat_name)
+                test_idx = np.where(test_mask_f)[0]
+                train_idx = np.where(train_mask_f)[0]
                 if len(test_idx) < 10 or len(train_idx) < 10:
                     pbar.update(1)
                     continue
 
-                X_train, X_test = X_ep[train_idx], X_ep[test_idx]
-                y_train, y_test = ep_values[train_idx], ep_values[test_idx]
-
-                # Structural 1-NN distances
+                y_train = ep_values[train_idx]
+                y_test = ep_values[test_idx]
                 struct_nn1 = D_ep[np.ix_(test_idx, train_idx)].min(axis=1)
-
-                # Target-space 1-NN distances
                 target_nn1 = np.abs(y_test[:, None] - y_train[None, :]).min(axis=1)
-
                 test_names = ep_names[test_idx]
 
-                cache_dir = INTERIM_DATA_DIR / "optuna_cache"
-                model, _, _ = tune_xgboost(X_train, y_train, cache_dir=cache_dir, cache_key=f"{ep}_{strat_name}_fold{fold_id}")
-                y_pred = model.predict(X_test)
-                sq_errors = (y_pred - y_test) ** 2
+                if model == "xgboost":
+                    cache_dir = INTERIM_DATA_DIR / "optuna_cache"
+                    fitted_model, _, _ = tune_xgboost(
+                        X_ep[train_idx], y_train,
+                        cache_dir=cache_dir,
+                        cache_key=f"{ep}_{strat_name}_fold{fold_id}",
+                    )
+                    y_pred = fitted_model.predict(X_ep[test_idx])
+                else:
+                    train_smiles = [ep_prot_smiles[i] for i in train_idx]
+                    test_smiles = [ep_prot_smiles[i] for i in test_idx]
+                    y_pred = train_chemprop(
+                        train_smiles, y_train, test_smiles,
+                        cache_dir=chemprop_cache_dir,
+                        cache_key=f"2.07_{ep}_{strat_name}_fold{fold_id}",
+                    )
 
-                # Competition metrics
+                sq_errors = (y_pred - y_test) ** 2
                 mae = mean_absolute_error(y_test, y_pred)
                 r2 = r2_score(y_test, y_pred)
                 sp_r, _ = spearmanr(y_test, y_pred)
@@ -395,299 +666,49 @@ def main(
                 rae = mae / baseline_mad if baseline_mad > 0 else np.nan
 
                 all_results.append({
-                    "endpoint": ep,
-                    "strategy": strat_name,
-                    "fold": fold_id,
-                    "n_train": len(train_idx),
-                    "n_test": len(test_idx),
-                    "struct_dist": struct_nn1,
-                    "target_dist": target_nn1,
+                    "endpoint": ep, "strategy": strat_name, "fold": fold_id,
+                    "n_train": len(train_idx), "n_test": len(test_idx),
+                    "struct_dist": struct_nn1, "target_dist": target_nn1,
                     "sq_errors": sq_errors,
-                    "mae": mae,
-                    "r2": r2,
-                    "spearman_r": sp_r,
-                    "kendall_tau": kt,
-                    "rae": rae,
-                    "overall_rmse": np.sqrt(sq_errors.mean()),
+                    "mae": mae, "r2": r2, "spearman_r": sp_r,
+                    "kendall_tau": kt, "rae": rae,
+                    "overall_rmse": float(np.sqrt(sq_errors.mean())),
                 })
 
-                # Store per-molecule predictions
                 for j in range(len(test_idx)):
                     prediction_rows.append({
                         "Molecule Name": test_names[j],
-                        "endpoint": ep,
-                        "strategy": strat_name,
-                        "fold": fold_id,
-                        "y_true": y_test[j],
-                        "y_pred": y_pred[j],
-                        "struct_1nn": struct_nn1[j],
-                        "target_1nn": target_nn1[j],
+                        "endpoint": ep, "strategy": strat_name, "fold": fold_id,
+                        "y_true": float(y_test[j]), "y_pred": float(y_pred[j]),
+                        "struct_1nn": float(struct_nn1[j]),
+                        "target_1nn": float(target_nn1[j]),
                     })
 
-                pbar.set_postfix_str(f"{ep} {strat_name} f{fold_id} ({len(train_idx)}:{len(test_idx)})")
+                pbar.set_postfix_str(f"{ep} {strat_name} f{fold_id}")
                 pbar.update(1)
 
     pbar.close()
 
-    # ── 4. Plot: Overall performance summary ────────────────────────
-    logger.info("Plotting overall performance summary")
-    perf_rows = []
-    for r in all_results:
-        perf_rows.append({
-            "endpoint": r["endpoint"],
-            "strategy": r["strategy"],
-            "fold": r["fold"],
-            "n_train": r["n_train"],
-            "n_test": r["n_test"],
-            "mae": r["mae"],
-            "r2": r["r2"],
-            "spearman_r": r["spearman_r"],
-            "kendall_tau": r["kendall_tau"],
-            "rae": r["rae"],
-            "rmse": r["overall_rmse"],
-        })
+    # ── 4. Save per-fold performance table ────────────────────────────────
+    perf_rows = [
+        {"endpoint": r["endpoint"], "strategy": r["strategy"], "fold": r["fold"],
+         "n_train": r["n_train"], "n_test": r["n_test"],
+         "mae": r["mae"], "r2": r["r2"], "spearman_r": r["spearman_r"],
+         "kendall_tau": r["kendall_tau"], "rae": r["rae"], "rmse": r["overall_rmse"]}
+        for r in all_results
+    ]
     perf_df = pd.DataFrame(perf_rows)
-
-    active_endpoints = sorted(perf_df["endpoint"].unique())
-    n_ep = len(active_endpoints)
-
-    strat_colors = {"cluster": "steelblue", "time": "coral", "target": "forestgreen"}
-
-    for metric, ylabel in [
-        ("mae", "MAE"),
-        ("spearman_r", "Spearman ρ"),
-        ("rae", "RAE"),
-    ]:
-        fig, ax = plt.subplots(figsize=(14, 6))
-
-        x = np.arange(n_ep)
-        width = 0.25
-        for i, strat_name in enumerate(STRATEGIES):
-            strat_sub = perf_df[perf_df["strategy"] == strat_name]
-            means = []
-            stds = []
-            for ep in active_endpoints:
-                ep_vals = strat_sub[strat_sub["endpoint"] == ep][metric]
-                means.append(ep_vals.mean())
-                stds.append(ep_vals.std())
-            ax.bar(x + i * width, means, width, yerr=stds, label=strat_name,
-                   color=strat_colors[strat_name], edgecolor="white", capsize=3, alpha=0.8)
-
-        ax.set_xticks(x + width)
-        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
-        ax.set_ylabel(ylabel)
-        ax.set_title(f"{ylabel} by endpoint and split strategy — XGBoost")
-        ax.legend(fontsize=8)
-        if metric == "rae":
-            ax.axhline(y=1, color="gray", linestyle="--", alpha=0.3)
-
-        fig.tight_layout()
-        fig.savefig(output_dir / f"overall_{metric}.png", dpi=dpi, bbox_inches="tight")
-        logger.info(f"Saved overall_{metric}.png")
-        plt.close("all")
-
-    # R² plot: separate cluster+time (interpretable) from target (catastrophic)
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(18, 6), gridspec_kw={"width_ratios": [2, 1]})
-
-    x = np.arange(n_ep)
-    width = 0.35
-    for i, strat_name in enumerate(["cluster", "time"]):
-        strat_sub = perf_df[perf_df["strategy"] == strat_name]
-        means = []
-        stds = []
-        for ep in active_endpoints:
-            ep_vals = strat_sub[strat_sub["endpoint"] == ep]["r2"]
-            means.append(ep_vals.mean())
-            stds.append(ep_vals.std())
-        ax1.bar(x + i * width, means, width, yerr=stds, label=strat_name,
-               color=strat_colors[strat_name], edgecolor="white", capsize=3, alpha=0.8)
-
-    ax1.set_xticks(x + width / 2)
-    ax1.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
-    ax1.set_ylabel("R²")
-    ax1.set_title("R² — Cluster & Time splits")
-    ax1.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
-    ax1.legend(fontsize=8)
-
-    # Target-split R² (log-scale of |R²| since values are deeply negative)
-    target_sub = perf_df[perf_df["strategy"] == "target"]
-    target_means = []
-    for ep in active_endpoints:
-        ep_vals = target_sub[target_sub["endpoint"] == ep]["r2"]
-        target_means.append(ep_vals.mean())
-    ax2.barh(np.arange(n_ep), target_means, color=strat_colors["target"], alpha=0.8)
-    ax2.set_yticks(np.arange(n_ep))
-    ax2.set_yticklabels(active_endpoints, fontsize=8)
-    ax2.set_xlabel("R²")
-    ax2.set_title("R² — Target split (note scale)")
-    ax2.axvline(x=0, color="gray", linestyle="--", alpha=0.3)
-
-    fig.suptitle("R² by endpoint and split strategy — XGBoost", fontsize=14, y=1.02)
-    fig.tight_layout()
-    fig.savefig(output_dir / "overall_r2.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved overall_r2.png")
-    plt.close("all")
-
-    # Log MA-RAE per strategy
-    for strat_name in STRATEGIES:
-        strat_sub = perf_df[perf_df["strategy"] == strat_name]
-        ma_rae = strat_sub.groupby("fold")["rae"].mean().mean()
-        logger.info(f"MA-RAE ({strat_name}): {ma_rae:.3f}")
-
-    # Save per-fold performance table
-    perf_df.to_csv(output_dir / "per_fold_performance.csv", index=False)
+    perf_df.to_csv(model_dir / "per_fold_performance.csv", index=False)
     logger.info(f"Saved per_fold_performance.csv ({len(perf_df)} rows)")
 
-    # ── 5. Plot: Performance over structural distance ─────────────────
-    logger.info("Plotting performance over structural distance")
-    active_endpoints = sorted(set(r["endpoint"] for r in all_results))
-    n_ep = len(active_endpoints)
-    nrows = (n_ep + 2) // 3
-    ncols = min(n_ep, 3)
-
-    summary_rows = []
-
-    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 5 * nrows))
-    if n_ep == 1:
-        axes = np.array([axes])
-    axes = axes.flatten()
-
-    for ax_idx, ep in enumerate(active_endpoints):
-        ax = axes[ax_idx]
-        ep_results = [r for r in all_results if r["endpoint"] == ep]
-
-        # Pool all distances for shared binning
-        all_dists = np.concatenate([r["struct_dist"] for r in ep_results])
-        bins = make_sliding_bins(all_dists)
-
-        for strat_name in STRATEGIES:
-            strat_results = [r for r in ep_results if r["strategy"] == strat_name]
-            if not strat_results:
-                continue
-
-            # Per-fold curves
-            fold_curves = []
-            for r in strat_results:
-                curve = bin_performance(r["struct_dist"], r["sq_errors"], bins)
-                fold_curves.append(curve)
-
-            centers = sorted(fold_curves[0].keys())
-            values = np.array([[c[center] for center in centers] for c in fold_curves])
-
-            median_vals = np.nanmedian(values, axis=0)
-            lo_vals = np.nanpercentile(values, 10, axis=0)
-            hi_vals = np.nanpercentile(values, 90, axis=0)
-
-            valid = ~np.isnan(median_vals)
-            c_arr = np.array(centers)
-
-            color = strat_colors[strat_name]
-            ax.plot(c_arr[valid], median_vals[valid], color=color,
-                    label=strat_name, linewidth=1.5)
-            ax.fill_between(c_arr[valid], lo_vals[valid], hi_vals[valid],
-                            color=color, alpha=0.1)
-
-            # Summary stats
-            overall = np.median([r["overall_rmse"] for r in strat_results])
-            valid_medians = median_vals[valid]
-            if len(valid_medians) > 0:
-                summary_rows.append({
-                    "endpoint": ep,
-                    "strategy": strat_name,
-                    "overall_rmse": float(overall),
-                    "rmse_closest_bin": float(valid_medians[0]),
-                    "rmse_farthest_bin": float(valid_medians[-1]),
-                    "degradation_ratio": float(valid_medians[-1] / valid_medians[0]) if valid_medians[0] > 0 else np.nan,
-                })
-
-        ax.set_xlabel("Test-to-train 1-NN distance (Tanimoto)")
-        ax.set_ylabel("RMSE")
-        ax.set_title(ep)
-        ax.legend(fontsize=7)
-
-    for i in range(n_ep, len(axes)):
-        axes[i].set_visible(False)
-
-    fig.suptitle("Performance over structural distance — XGBoost", fontsize=14, y=1.02)
-    fig.tight_layout()
-    fig.savefig(output_dir / "performance_over_distance.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved performance_over_distance.png")
-    plt.close("all")
-
-    # ── 6. Plot: Performance over target-space distance ───────────────
-    logger.info("Plotting performance over target-space distance")
-    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 5 * nrows))
-    if n_ep == 1:
-        axes = np.array([axes])
-    axes = axes.flatten()
-
-    for ax_idx, ep in enumerate(active_endpoints):
-        ax = axes[ax_idx]
-        ep_results = [r for r in all_results if r["endpoint"] == ep]
-
-        all_dists = np.concatenate([r["target_dist"] for r in ep_results])
-        bins = make_sliding_bins(all_dists)
-
-        for strat_name in STRATEGIES:
-            strat_results = [r for r in ep_results if r["strategy"] == strat_name]
-            if not strat_results:
-                continue
-
-            fold_curves = []
-            for r in strat_results:
-                curve = bin_performance(r["target_dist"], r["sq_errors"], bins)
-                fold_curves.append(curve)
-
-            centers = sorted(fold_curves[0].keys())
-            values = np.array([[c[center] for center in centers] for c in fold_curves])
-
-            median_vals = np.nanmedian(values, axis=0)
-            lo_vals = np.nanpercentile(values, 10, axis=0)
-            hi_vals = np.nanpercentile(values, 90, axis=0)
-
-            valid = ~np.isnan(median_vals)
-            c_arr = np.array(centers)
-
-            color = strat_colors[strat_name]
-            ax.plot(c_arr[valid], median_vals[valid], color=color,
-                    label=strat_name, linewidth=1.5)
-            ax.fill_between(c_arr[valid], lo_vals[valid], hi_vals[valid],
-                            color=color, alpha=0.1)
-
-        ax.set_xlabel("Test-to-train 1-NN distance (target space)")
-        ax.set_ylabel("RMSE")
-        ax.set_title(ep)
-        ax.legend(fontsize=7)
-
-    for i in range(n_ep, len(axes)):
-        axes[i].set_visible(False)
-
-    fig.suptitle("Performance over target-space distance — XGBoost", fontsize=14, y=1.02)
-    fig.tight_layout()
-    fig.savefig(output_dir / "performance_over_target_distance.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved performance_over_target_distance.png")
-    plt.close("all")
-
-    # ── 7. Save summary ──────────────────────────────────────────────
-    summary_df = pd.DataFrame(summary_rows)
-    summary_df.to_csv(output_dir / "performance_distance_summary.csv", index=False)
-    logger.info(f"Saved performance_distance_summary.csv ({len(summary_df)} rows)")
-
-    for _, row in summary_df.iterrows():
-        logger.info(
-            f"  {row['endpoint']} {row['strategy']}: "
-            f"overall={row['overall_rmse']:.3f}, "
-            f"closest={row['rmse_closest_bin']:.3f}, "
-            f"farthest={row['rmse_farthest_bin']:.3f}, "
-            f"degradation={row['degradation_ratio']:.2f}x"
-        )
-
-    # Save predictions
     pred_df = pd.DataFrame(prediction_rows)
-    pred_df.to_parquet(output_dir / "predictions.parquet", index=False)
+    pred_df.to_parquet(model_dir / "predictions.parquet", index=False)
     logger.info(f"Saved predictions.parquet ({len(pred_df)} rows)")
 
-    logger.info(f"All outputs saved to {output_dir}")
+    # ── 5. Generate figures ───────────────────────────────────────────────
+    _generate_figures(all_results, perf_df, pred_df, model_dir, model, dpi)
+
+    logger.info(f"All outputs saved to {model_dir}")
 
 
 if __name__ == "__main__":

--- a/notebooks/2.07-seal-performance-distance.py
+++ b/notebooks/2.07-seal-performance-distance.py
@@ -655,6 +655,7 @@ def main(
                         train_smiles, y_train, test_smiles,
                         cache_dir=chemprop_cache_dir,
                         cache_key=f"2.07_{ep}_{strat_name}_fold{fold_id}",
+                        checkpoint_dir=model_dir / "models",
                     )
 
                 sq_errors = (y_pred - y_test) ** 2

--- a/notebooks/2.08-seal-baseline-performance.py
+++ b/notebooks/2.08-seal-baseline-performance.py
@@ -407,6 +407,7 @@ def main(
                 train_prot, y_tr, test_prot,
                 cache_dir=chemprop_cache,
                 cache_key=f"2.08_{ep}_baseline",
+                checkpoint_dir=model_dir / "models",
             )
 
         mae = mean_absolute_error(y_te, y_pred)

--- a/notebooks/2.08-seal-baseline-performance.py
+++ b/notebooks/2.08-seal-baseline-performance.py
@@ -1,28 +1,34 @@
 #!/usr/bin/env python
-"""Baseline XGBoost performance on the original train/test split.
+"""Baseline model performance on the original train/test split.
 
-Trains XGBoost on ECFP4 + full RDKit 2D descriptors (~200) using the
-competition train/test split (5,326 / 2,282). Molecules are protonated at the
-relevant assay pH using dimorphite_dl before feature computation:
+Trains XGBoost or Chemprop D-MPNN on the competition split (5,326 / 2,282).
+Molecules are protonated at the relevant assay pH using dimorphite_dl:
   - pH 7.4: LogD, KSOL, HLM/MLM CLint, MPPB, MBPB, MGMB
   - pH 6.5: Caco-2 Papp A>B, Caco-2 Efflux (apical compartment)
 
-Uses Optuna TPE to tune hyperparameters per endpoint via 3-fold CV.
-For endpoints not already on log scale (everything except LogD), both training
-targets and evaluation are log-transformed via log10(clip(x, 1e-10) + 1),
-matching the OpenADMET competition evaluation protocol.
+XGBoost uses ECFP4 + full RDKit 2D descriptors (~200), Optuna TPE-tuned per endpoint.
+Chemprop D-MPNN uses default hyperparameters (hidden_dim=300, depth=3, 50 epochs).
+
+For endpoints not on log scale (everything except LogD), targets are log-transformed
+via log10(clip(x, 1e-10) + 1), matching the OpenADMET competition protocol.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py
+    pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --combined
 
-Outputs:
-    data/processed/2.08-seal-baseline-performance/overall_metrics.csv
-    data/processed/2.08-seal-baseline-performance/predictions.parquet
-    data/processed/2.08-seal-baseline-performance/best_params.csv
-    data/processed/2.08-seal-baseline-performance/r2_by_endpoint.png
-    data/processed/2.08-seal-baseline-performance/mae_by_endpoint.png
-    data/processed/2.08-seal-baseline-performance/spearman_by_endpoint.png
-    data/processed/2.08-seal-baseline-performance/scatter_predictions.png
+Outputs (per model):
+    data/processed/2.08-seal-baseline-performance/{model}/overall_metrics.csv
+    data/processed/2.08-seal-baseline-performance/{model}/predictions.parquet
+    data/processed/2.08-seal-baseline-performance/{model}/best_params.csv  (xgboost only)
+    data/processed/2.08-seal-baseline-performance/{model}/r2_by_endpoint.png
+    data/processed/2.08-seal-baseline-performance/{model}/mae_by_endpoint.png
+    data/processed/2.08-seal-baseline-performance/{model}/spearman_by_endpoint.png
+    data/processed/2.08-seal-baseline-performance/{model}/scatter_predictions.png
+
+Combined outputs:
+    data/processed/2.08-seal-baseline-performance/combined/metrics_comparison.csv
+    data/processed/2.08-seal-baseline-performance/combined/{metric}_comparison.png
 """
 
 from pathlib import Path
@@ -40,9 +46,16 @@ from scipy.stats import kendalltau, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    MODEL_COLORS,
+    MODEL_LABELS,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -56,7 +69,6 @@ ENDPOINTS = [
 
 LOG_TRANSFORM_ENDPOINTS = [ep for ep in ENDPOINTS if ep.lower() != "logd"]
 
-# Assay pH per endpoint
 ENDPOINT_PH = {
     "LogD": 7.4,
     "KSOL": 7.4,
@@ -69,18 +81,17 @@ ENDPOINT_PH = {
     "MGMB": 7.4,
 }
 
-# Full RDKit 2D descriptor suite
 DESCRIPTOR_NAMES = [name for name, _ in Descriptors.descList]
 DESC_CALC = MolecularDescriptorCalculator(DESCRIPTOR_NAMES)
 
 
+# ── Utilities ─────────────────────────────────────────────────────────────────
+
 def clip_and_log_transform(x: np.ndarray) -> np.ndarray:
-    """Log-transform matching competition evaluation: log10(clip(x, 1e-10) + 1)."""
     return np.log10(np.clip(x, 1e-10, None) + 1)
 
 
 def protonate_at_ph(smiles_list: list[str], ph: float) -> list[str]:
-    """Protonate SMILES at given pH using dimorphite_dl. Returns most probable form."""
     protonated = []
     for smi in smiles_list:
         try:
@@ -92,7 +103,6 @@ def protonate_at_ph(smiles_list: list[str], ph: float) -> list[str]:
 
 
 def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) -> np.ndarray:
-    """Compute ECFP4 fingerprints and return as dense numpy array."""
     fps = []
     for smi in smiles_list:
         mol = Chem.MolFromSmiles(smi)
@@ -105,7 +115,6 @@ def compute_ecfp4(smiles_list: list[str], nbits: int = 2048, radius: int = 2) ->
 
 
 def compute_rdkit_descriptors(smiles_list: list[str]) -> np.ndarray:
-    """Compute full RDKit 2D descriptor suite (~200 descriptors)."""
     rows = []
     for smi in smiles_list:
         mol = Chem.MolFromSmiles(smi)
@@ -114,16 +123,169 @@ def compute_rdkit_descriptors(smiles_list: list[str]) -> np.ndarray:
         else:
             rows.append(list(DESC_CALC.CalcDescriptors(mol)))
     arr = np.array(rows, dtype=np.float64)
-    arr = np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0)
-    return arr
+    return np.nan_to_num(arr, nan=0.0, posinf=0.0, neginf=0.0)
 
 
-def compute_features(smiles_list: list[str]) -> np.ndarray:
-    """Compute ECFP4 + full RDKit 2D descriptors, scaled and concatenated."""
-    ecfp = compute_ecfp4(smiles_list)
-    desc = compute_rdkit_descriptors(smiles_list)
-    return ecfp, desc
+def compute_features(smiles_list: list[str]) -> tuple[np.ndarray, np.ndarray]:
+    return compute_ecfp4(smiles_list), compute_rdkit_descriptors(smiles_list)
 
+
+# ── Migration ─────────────────────────────────────────────────────────────────
+
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move pre-model-flag XGBoost outputs into xgboost/ subdirectory."""
+    flat_files = [
+        "overall_metrics.csv", "predictions.parquet", "best_params.csv",
+        "r2_by_endpoint.png", "mae_by_endpoint.png", "spearman_by_endpoint.png",
+        "scatter_predictions.png",
+    ]
+    xgboost_dir = output_dir / "xgboost"
+    migrated = []
+    for fname in flat_files:
+        src = output_dir / fname
+        dst = xgboost_dir / fname
+        if src.exists() and not dst.exists():
+            xgboost_dir.mkdir(parents=True, exist_ok=True)
+            src.rename(dst)
+            migrated.append(fname)
+    if migrated:
+        logger.info(f"Migrated {len(migrated)} existing files → xgboost/")
+
+
+# ── Figure generation ─────────────────────────────────────────────────────────
+
+def _generate_figures(
+    pred_df: pd.DataFrame,
+    metrics_df: pd.DataFrame,
+    model_dir: Path,
+    model: str,
+    dpi: int,
+) -> None:
+    """Generate all per-model figures from prediction and metrics dataframes."""
+    active_endpoints = sorted(metrics_df["endpoint"].unique())
+    x = np.arange(len(active_endpoints))
+    width = 0.6
+    model_label = MODEL_LABELS.get(model, model)
+    model_color = MODEL_COLORS.get(model, "steelblue")
+
+    ci_map = {
+        "r2": ("r2_ci_lo", "r2_ci_hi"),
+        "mae": ("mae_ci_lo", "mae_ci_hi"),
+        "spearman_r": ("spearman_ci_lo", "spearman_ci_hi"),
+    }
+
+    for metric, ylabel, fname in [
+        ("r2", "R²", "r2_by_endpoint"),
+        ("mae", "MAE (log-scale)", "mae_by_endpoint"),
+        ("spearman_r", "Spearman ρ", "spearman_by_endpoint"),
+    ]:
+        fig, ax = plt.subplots(figsize=(10, 5))
+        vals = [metrics_df.loc[metrics_df["endpoint"] == ep, metric].values[0] for ep in active_endpoints]
+
+        lo_col, hi_col = ci_map[metric]
+        ci_lo = [metrics_df.loc[metrics_df["endpoint"] == ep, lo_col].values[0] for ep in active_endpoints]
+        ci_hi = [metrics_df.loc[metrics_df["endpoint"] == ep, hi_col].values[0] for ep in active_endpoints]
+        yerr = np.array([[v - lo, hi - v] for v, lo, hi in zip(vals, ci_lo, ci_hi)]).T
+
+        ax.bar(x, vals, width, color=model_color, edgecolor="white", alpha=0.8,
+               yerr=yerr, capsize=4, error_kw={"linewidth": 1.2})
+        ax.set_xticks(x)
+        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
+        ax.set_ylabel(ylabel)
+        ax.set_title(f"{ylabel} by endpoint — {model_label} (original split)")
+        if metric == "r2":
+            ax.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
+
+        fig.tight_layout()
+        fig.savefig(model_dir / f"{fname}.png", dpi=dpi, bbox_inches="tight")
+        logger.info(f"Saved {fname}.png")
+        plt.close("all")
+
+    # Scatter: y_true vs y_pred
+    n_ep = len(active_endpoints)
+    ncols = min(n_ep, 3)
+    nrows = (n_ep + ncols - 1) // ncols
+    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 5 * nrows))
+    axes = np.array(axes).flatten()
+
+    for ax_idx, ep in enumerate(active_endpoints):
+        ax = axes[ax_idx]
+        ep_pred = pred_df[pred_df["endpoint"] == ep]
+        ax.scatter(ep_pred["y_true"], ep_pred["y_pred"], s=5, alpha=0.3,
+                   color=model_color, rasterized=True)
+
+        lo = min(ep_pred["y_true"].min(), ep_pred["y_pred"].min())
+        hi = max(ep_pred["y_true"].max(), ep_pred["y_pred"].max())
+        ax.plot([lo, hi], [lo, hi], "k--", alpha=0.3, linewidth=1)
+
+        r2_val = metrics_df.loc[metrics_df["endpoint"] == ep, "r2"].values[0]
+        ax.text(0.05, 0.95, f"R²={r2_val:.3f}", transform=ax.transAxes,
+                fontsize=8, verticalalignment="top", color=model_color)
+
+        suffix = " (log)" if ep in LOG_TRANSFORM_ENDPOINTS else ""
+        ax.set_xlabel(f"True{suffix}")
+        ax.set_ylabel(f"Predicted{suffix}")
+        ax.set_title(ep)
+
+    for i in range(n_ep, len(axes)):
+        axes[i].set_visible(False)
+
+    fig.suptitle(f"Predictions vs true — {model_label} (original split)", fontsize=14, y=1.02)
+    fig.tight_layout()
+    fig.savefig(model_dir / "scatter_predictions.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved scatter_predictions.png")
+    plt.close("all")
+
+
+# ── Combined figures ──────────────────────────────────────────────────────────
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Load both models' metrics and produce side-by-side comparison figures."""
+    xgb_path = output_dir / "xgboost" / "overall_metrics.csv"
+    chemprop_path = output_dir / "chemprop" / "overall_metrics.csv"
+
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    if missing:
+        logger.error(f"Missing results for: {missing}. Run those models first.")
+        return
+
+    combined_dir = output_dir / "combined"
+    combined_dir.mkdir(parents=True, exist_ok=True)
+
+    xgb = pd.read_csv(xgb_path)
+    chemprop = pd.read_csv(chemprop_path)
+
+    # Comparison CSV
+    merge_cols = ["endpoint", "mae", "r2", "spearman_r", "rae", "kendall_tau"]
+    comparison_df = (
+        xgb[merge_cols].rename(columns={c: f"{c}_xgboost" for c in merge_cols if c != "endpoint"})
+        .merge(
+            chemprop[merge_cols].rename(columns={c: f"{c}_chemprop" for c in merge_cols if c != "endpoint"}),
+            on="endpoint",
+        )
+    )
+    comparison_df.to_csv(combined_dir / "metrics_comparison.csv", index=False)
+    logger.info("Saved metrics_comparison.csv")
+
+    # Grouped bar charts
+    data_by_model = {"xgboost": xgb, "chemprop": chemprop}
+    for metric, ylabel, fname in [
+        ("r2", "R²", "r2_comparison"),
+        ("mae", "MAE", "mae_comparison"),
+        ("spearman_r", "Spearman ρ", "spearman_comparison"),
+        ("rae", "RAE", "rae_comparison"),
+    ]:
+        plot_model_comparison_bars(
+            data_by_model, "endpoint", metric, ylabel,
+            f"{ylabel} — XGBoost vs Chemprop (original split)",
+            combined_dir / f"{fname}.png", dpi=dpi,
+        )
+        logger.info(f"Saved {fname}.png")
+
+    logger.info(f"Combined figures saved to {combined_dir}")
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
 
 @app.command()
 def main(
@@ -131,9 +293,34 @@ def main(
         PROCESSED_DATA_DIR / "2.08-seal-baseline-performance", help="Output directory"
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if combined:
+        _generate_combined_figures(output_dir, dpi)
+        return
+
+    if model not in ("xgboost", "chemprop"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+        raise typer.Exit(1)
+
+    _migrate_flat_outputs(output_dir)
+
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Skip training if predictions already exist ────────────────────
+    pred_path = model_dir / "predictions.parquet"
+    metrics_path = model_dir / "overall_metrics.csv"
+    if pred_path.exists() and metrics_path.exists():
+        logger.info(f"Existing {model} predictions found — regenerating figures only")
+        pred_df = pd.read_parquet(pred_path)
+        metrics_df = pd.read_csv(metrics_path)
+        _generate_figures(pred_df, metrics_df, model_dir, model, dpi)
+        return
 
     # ── 1. Load data ──────────────────────────────────────────────────
     logger.info("Loading data")
@@ -147,38 +334,41 @@ def main(
     train_names = train_df["Molecule Name"].values
     test_names = test_df["Molecule Name"].values
 
-    # ── 2. Protonate at each unique pH and compute features ──────────
+    # ── 2. Protonate at each unique pH (both models use pH-appropriate SMILES) ──
     unique_phs = sorted(set(ENDPOINT_PH.values()))
-    features_by_ph: dict[float, dict] = {}
-
+    prot_by_ph: dict[float, dict] = {}
     for ph in unique_phs:
         logger.info(f"Protonating at pH {ph}")
-        train_prot = protonate_at_ph(train_smiles, ph)
-        test_prot = protonate_at_ph(test_smiles, ph)
+        prot_by_ph[ph] = {
+            "train": protonate_at_ph(train_smiles, ph),
+            "test": protonate_at_ph(test_smiles, ph),
+        }
 
-        logger.info(f"Computing features at pH {ph}")
-        ecfp_tr, desc_tr = compute_features(train_prot)
-        ecfp_te, desc_te = compute_features(test_prot)
+    # ── 3. XGBoost: compute ECFP4 + RDKit 2D features ────────────────
+    features_by_ph: dict[float, dict] = {}
+    if model == "xgboost":
+        for ph in unique_phs:
+            logger.info(f"Computing XGBoost features at pH {ph}")
+            ecfp_tr, desc_tr = compute_features(prot_by_ph[ph]["train"])
+            ecfp_te, desc_te = compute_features(prot_by_ph[ph]["test"])
 
-        # Remove zero-variance descriptors (fit on train)
-        variance = desc_tr.var(axis=0)
-        nonzero_var = variance > 0
-        desc_tr = desc_tr[:, nonzero_var]
-        desc_te = desc_te[:, nonzero_var]
+            nonzero_var = desc_tr.var(axis=0) > 0
+            desc_tr = desc_tr[:, nonzero_var]
+            desc_te = desc_te[:, nonzero_var]
 
-        # Scale descriptors
-        scaler = StandardScaler()
-        desc_tr_scaled = scaler.fit_transform(desc_tr)
-        desc_te_scaled = scaler.transform(desc_te)
+            scaler = StandardScaler()
+            desc_tr_s = scaler.fit_transform(desc_tr)
+            desc_te_s = scaler.transform(desc_te)
 
-        X_tr = np.hstack([ecfp_tr, desc_tr_scaled])
-        X_te = np.hstack([ecfp_te, desc_te_scaled])
-        logger.info(f"  pH {ph}: {X_tr.shape[1]} features (2048 ECFP + {desc_tr.shape[1]} RDKit 2D)")
+            X_tr = np.hstack([ecfp_tr, desc_tr_s])
+            X_te = np.hstack([ecfp_te, desc_te_s])
+            logger.info(f"  pH {ph}: {X_tr.shape[1]} features (2048 ECFP + {desc_tr.shape[1]} RDKit 2D)")
+            features_by_ph[ph] = {"X_train": X_tr, "X_test": X_te}
 
-        features_by_ph[ph] = {"X_train": X_tr, "X_test": X_te}
+    # ── 4. Train and evaluate per endpoint ───────────────────────────
+    optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
+    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
 
-    # ── 3. Train and evaluate per endpoint ────────────────────────────
-    cache_dir = INTERIM_DATA_DIR / "optuna_cache"
     metric_rows = []
     prediction_rows = []
     best_params_rows = []
@@ -186,37 +376,38 @@ def main(
     for ep in ENDPOINTS:
         train_mask = train_df[ep].notna().values
         test_mask = test_df[ep].notna().values
+        n_train, n_test = train_mask.sum(), test_mask.sum()
 
-        n_train = train_mask.sum()
-        n_test = test_mask.sum()
         if n_test < 10:
             logger.warning(f"Skipping {ep}: only {n_test} test molecules")
             continue
 
         ph = ENDPOINT_PH[ep]
-        X_tr = features_by_ph[ph]["X_train"][train_mask]
-        X_te = features_by_ph[ph]["X_test"][test_mask]
         y_tr_raw = train_df[ep].values[train_mask]
         y_te_raw = test_df[ep].values[test_mask]
         te_names = test_names[test_mask]
 
-        # Log-transform targets for training and evaluation (except LogD)
-        if ep in LOG_TRANSFORM_ENDPOINTS:
-            y_tr = clip_and_log_transform(y_tr_raw)
-            y_te = clip_and_log_transform(y_te_raw)
-        else:
-            y_tr = y_tr_raw
-            y_te = y_te_raw
+        y_tr = clip_and_log_transform(y_tr_raw) if ep in LOG_TRANSFORM_ENDPOINTS else y_tr_raw
+        y_te = clip_and_log_transform(y_te_raw) if ep in LOG_TRANSFORM_ENDPOINTS else y_te_raw
 
-        # Baseline RAE denominator (competition formula: mean(|true - mean(true)|))
         baseline_mad = np.mean(np.abs(y_te - np.mean(y_te)))
 
-        logger.info(f"  {ep} ({n_train} train, {n_test} test, pH={ph}) — tuning XGBoost")
-        model, best, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_baseline")
-        logger.info(f"    Best params: {best}")
-
-        best_params_rows.append({"endpoint": ep, "ph": ph, **best})
-        y_pred = model.predict(X_te)
+        if model == "xgboost":
+            X_tr = features_by_ph[ph]["X_train"][train_mask]
+            X_te = features_by_ph[ph]["X_test"][test_mask]
+            logger.info(f"  {ep} ({n_train} train, {n_test} test) — tuning XGBoost")
+            model_obj, best, _ = tune_xgboost(X_tr, y_tr, cache_dir=optuna_cache, cache_key=f"{ep}_baseline")
+            best_params_rows.append({"endpoint": ep, "ph": ph, **best})
+            y_pred = model_obj.predict(X_te)
+        else:
+            train_prot = [s for s, m in zip(prot_by_ph[ph]["train"], train_mask) if m]
+            test_prot = [s for s, m in zip(prot_by_ph[ph]["test"], test_mask) if m]
+            logger.info(f"  {ep} ({n_train} train, {n_test} test) — training Chemprop D-MPNN")
+            y_pred = train_chemprop(
+                train_prot, y_tr, test_prot,
+                cache_dir=chemprop_cache,
+                cache_key=f"2.08_{ep}_baseline",
+            )
 
         mae = mean_absolute_error(y_te, y_pred)
         r2 = r2_score(y_te, y_pred)
@@ -224,160 +415,77 @@ def main(
         kt, _ = kendalltau(y_te, y_pred)
         rae = mae / baseline_mad if baseline_mad > 0 else np.nan
 
+        logger.info(f"    MAE={mae:.3f}, R²={r2:.3f}, Spearman={sp_r:.3f}, RAE={rae:.3f}")
+
         metric_rows.append({
-            "endpoint": ep,
-            "ph": ph,
-            "n_train": n_train,
-            "n_test": n_test,
-            "mae": mae,
-            "r2": r2,
-            "spearman_r": sp_r,
-            "kendall_tau": kt,
-            "rae": rae,
-            "baseline_mad": baseline_mad,
+            "endpoint": ep, "ph": ph, "n_train": n_train, "n_test": n_test,
+            "mae": mae, "r2": r2, "spearman_r": sp_r, "kendall_tau": kt,
+            "rae": rae, "baseline_mad": baseline_mad,
             "log_transformed": ep in LOG_TRANSFORM_ENDPOINTS,
         })
-
-        logger.info(
-            f"    MAE={mae:.3f}, R2={r2:.3f}, "
-            f"Spearman={sp_r:.3f}, Kendall={kt:.3f}, RAE={rae:.3f}"
-        )
 
         for j in range(len(y_te)):
             prediction_rows.append({
                 "Molecule Name": te_names[j],
                 "endpoint": ep,
-                "y_true": y_te[j],
-                "y_pred": y_pred[j],
+                "y_true": float(y_te[j]),
+                "y_pred": float(y_pred[j]),
             })
 
     metrics_df = pd.DataFrame(metric_rows)
-    ma_rae = metrics_df["rae"].mean()
-    logger.info(f"MA-RAE: {ma_rae:.3f}")
+    logger.info(f"MA-RAE: {metrics_df['rae'].mean():.3f}")
 
-    # ── 4b. Bootstrap confidence intervals ───────────────────────────
+    # ── 5. Bootstrap 95% CIs ─────────────────────────────────────────
+    logger.info("Computing bootstrap 95% CIs (1000 resamples)")
     n_boot = 1000
     rng = np.random.default_rng(42)
     boot_rows = []
+
     for ep in metrics_df["endpoint"]:
         ep_preds = [r for r in prediction_rows if r["endpoint"] == ep]
         y_true = np.array([r["y_true"] for r in ep_preds])
-        y_pred = np.array([r["y_pred"] for r in ep_preds])
+        y_pred_arr = np.array([r["y_pred"] for r in ep_preds])
         baseline_mad = metrics_df.loc[metrics_df["endpoint"] == ep, "baseline_mad"].values[0]
+
         boot_mae, boot_r2, boot_sp, boot_rae = [], [], [], []
         for _ in range(n_boot):
             idx = rng.integers(0, len(y_true), size=len(y_true))
-            yt, yp = y_true[idx], y_pred[idx]
+            yt, yp = y_true[idx], y_pred_arr[idx]
             b_mae = mean_absolute_error(yt, yp)
             boot_mae.append(b_mae)
             boot_r2.append(r2_score(yt, yp))
             boot_sp.append(spearmanr(yt, yp).statistic)
             boot_rae.append(b_mae / baseline_mad if baseline_mad > 0 else np.nan)
+
         boot_rows.append({
             "endpoint": ep,
-            "mae_ci_lo": np.percentile(boot_mae, 2.5),
-            "mae_ci_hi": np.percentile(boot_mae, 97.5),
-            "r2_ci_lo": np.percentile(boot_r2, 2.5),
-            "r2_ci_hi": np.percentile(boot_r2, 97.5),
-            "spearman_ci_lo": np.percentile(boot_sp, 2.5),
-            "spearman_ci_hi": np.percentile(boot_sp, 97.5),
-            "rae_ci_lo": np.percentile(boot_rae, 2.5),
-            "rae_ci_hi": np.percentile(boot_rae, 97.5),
+            "mae_ci_lo": np.percentile(boot_mae, 2.5), "mae_ci_hi": np.percentile(boot_mae, 97.5),
+            "r2_ci_lo": np.percentile(boot_r2, 2.5), "r2_ci_hi": np.percentile(boot_r2, 97.5),
+            "spearman_ci_lo": np.percentile(boot_sp, 2.5), "spearman_ci_hi": np.percentile(boot_sp, 97.5),
+            "rae_ci_lo": np.percentile(boot_rae, 2.5), "rae_ci_hi": np.percentile(boot_rae, 97.5),
         })
         logger.info(
-            f"    {ep} 95% CI: R2=[{boot_rows[-1]['r2_ci_lo']:.3f}, {boot_rows[-1]['r2_ci_hi']:.3f}], "
+            f"  {ep}: R²=[{boot_rows[-1]['r2_ci_lo']:.3f}, {boot_rows[-1]['r2_ci_hi']:.3f}]  "
             f"RAE=[{boot_rows[-1]['rae_ci_lo']:.3f}, {boot_rows[-1]['rae_ci_hi']:.3f}]"
         )
-    boot_df = pd.DataFrame(boot_rows)
-    metrics_df = metrics_df.merge(boot_df, on="endpoint")
-    logger.info(f"Bootstrap 95% CIs computed ({n_boot} resamples)")
 
-    # ── 5. Save data ─────────────────────────────────────────────────
-    metrics_df.to_csv(output_dir / "overall_metrics.csv", index=False)
-    logger.info(f"Saved overall_metrics.csv ({len(metrics_df)} rows)")
+    metrics_df = metrics_df.merge(pd.DataFrame(boot_rows), on="endpoint")
 
-    params_df = pd.DataFrame(best_params_rows)
-    params_df.to_csv(output_dir / "best_params.csv", index=False)
-    logger.info("Saved best_params.csv")
-
+    # ── 6. Save ───────────────────────────────────────────────────────
     pred_df = pd.DataFrame(prediction_rows)
-    pred_df.to_parquet(output_dir / "predictions.parquet", index=False)
+    pred_df.to_parquet(pred_path, index=False)
     logger.info(f"Saved predictions.parquet ({len(pred_df)} rows)")
 
-    # ── 6. Plots ─────────────────────────────────────────────────────
-    active_endpoints = sorted(metrics_df["endpoint"].unique())
-    x = np.arange(len(active_endpoints))
-    width = 0.6
+    metrics_df.to_csv(metrics_path, index=False)
+    logger.info(f"Saved overall_metrics.csv ({len(metrics_df)} rows)")
 
-    ci_map = {
-        "r2": ("r2_ci_lo", "r2_ci_hi"),
-        "mae": ("mae_ci_lo", "mae_ci_hi"),
-        "spearman_r": ("spearman_ci_lo", "spearman_ci_hi"),
-    }
-    for metric, ylabel, fname in [
-        ("r2", "R²", "r2_by_endpoint"),
-        ("mae", "MAE (log-scale)", "mae_by_endpoint"),
-        ("spearman_r", "Spearman ρ", "spearman_by_endpoint"),
-    ]:
-        fig, ax = plt.subplots(figsize=(10, 5))
-        vals = [metrics_df[metrics_df["endpoint"] == ep][metric].values[0] for ep in active_endpoints]
-        lo_col, hi_col = ci_map[metric]
-        ci_lo = [metrics_df[metrics_df["endpoint"] == ep][lo_col].values[0] for ep in active_endpoints]
-        ci_hi = [metrics_df[metrics_df["endpoint"] == ep][hi_col].values[0] for ep in active_endpoints]
-        yerr = np.array([[v - lo, hi - v] for v, lo, hi in zip(vals, ci_lo, ci_hi)]).T
-        ax.bar(x, vals, width, color="steelblue", edgecolor="white", alpha=0.8,
-               yerr=yerr, capsize=4, error_kw={"linewidth": 1.2})
+    if model == "xgboost" and best_params_rows:
+        pd.DataFrame(best_params_rows).to_csv(model_dir / "best_params.csv", index=False)
+        logger.info("Saved best_params.csv")
 
-        ax.set_xticks(x)
-        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
-        ax.set_ylabel(ylabel)
-        ax.set_title(f"{ylabel} by endpoint — XGBoost baseline (original split)")
-        if metric == "r2":
-            ax.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
-
-        fig.tight_layout()
-        fig.savefig(output_dir / f"{fname}.png", dpi=dpi, bbox_inches="tight")
-        logger.info(f"Saved {fname}.png")
-        plt.close("all")
-
-    # Scatter: y_true vs y_pred (3x3 grid)
-    n_ep = len(active_endpoints)
-    nrows = (n_ep + 2) // 3
-    ncols = min(n_ep, 3)
-    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 5 * nrows))
-    axes = axes.flatten()
-
-    for ax_idx, ep in enumerate(active_endpoints):
-        ax = axes[ax_idx]
-        ep_pred = pred_df[pred_df["endpoint"] == ep]
-        ax.scatter(ep_pred["y_true"], ep_pred["y_pred"], s=5, alpha=0.3,
-                   color="steelblue", rasterized=True)
-
-        lo = min(ep_pred["y_true"].min(), ep_pred["y_pred"].min())
-        hi = max(ep_pred["y_true"].max(), ep_pred["y_pred"].max())
-        ax.plot([lo, hi], [lo, hi], "k--", alpha=0.3, linewidth=1)
-
-        row = metrics_df[metrics_df["endpoint"] == ep]
-        r2_val = row["r2"].values[0]
-        ax.text(0.05, 0.95, f"R²={r2_val:.3f}",
-                transform=ax.transAxes, fontsize=8, verticalalignment="top",
-                color="steelblue")
-
-        suffix = " (log)" if ep in LOG_TRANSFORM_ENDPOINTS else ""
-        ax.set_xlabel(f"True{suffix}")
-        ax.set_ylabel(f"Predicted{suffix}")
-        ax.set_title(ep)
-
-    for i in range(n_ep, len(axes)):
-        axes[i].set_visible(False)
-
-    fig.suptitle("Predictions vs true values — XGBoost baseline (original split)", fontsize=14, y=1.02)
-    fig.tight_layout()
-    fig.savefig(output_dir / "scatter_predictions.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved scatter_predictions.png")
-    plt.close("all")
-
-    logger.info(f"All outputs saved to {output_dir}")
+    # ── 7. Figures ────────────────────────────────────────────────────
+    _generate_figures(pred_df, metrics_df, model_dir, model, dpi)
+    logger.info(f"All outputs saved to {model_dir}")
 
 
 if __name__ == "__main__":

--- a/notebooks/2.08-seal-baseline-performance.py
+++ b/notebooks/2.08-seal-baseline-performance.py
@@ -62,9 +62,15 @@ RDLogger.DisableLog("rdApp.*")
 app = typer.Typer()
 
 ENDPOINTS = [
-    "LogD", "KSOL", "HLM CLint", "MLM CLint",
-    "Caco-2 Permeability Papp A>B", "Caco-2 Permeability Efflux",
-    "MPPB", "MBPB", "MGMB",
+    "LogD",
+    "KSOL",
+    "HLM CLint",
+    "MLM CLint",
+    "Caco-2 Permeability Papp A>B",
+    "Caco-2 Permeability Efflux",
+    "MPPB",
+    "MBPB",
+    "MGMB",
 ]
 
 LOG_TRANSFORM_ENDPOINTS = [ep for ep in ENDPOINTS if ep.lower() != "logd"]
@@ -86,6 +92,7 @@ DESC_CALC = MolecularDescriptorCalculator(DESCRIPTOR_NAMES)
 
 
 # ── Utilities ─────────────────────────────────────────────────────────────────
+
 
 def clip_and_log_transform(x: np.ndarray) -> np.ndarray:
     return np.log10(np.clip(x, 1e-10, None) + 1)
@@ -132,11 +139,16 @@ def compute_features(smiles_list: list[str]) -> tuple[np.ndarray, np.ndarray]:
 
 # ── Migration ─────────────────────────────────────────────────────────────────
 
+
 def _migrate_flat_outputs(output_dir: Path) -> None:
     """Move pre-model-flag XGBoost outputs into xgboost/ subdirectory."""
     flat_files = [
-        "overall_metrics.csv", "predictions.parquet", "best_params.csv",
-        "r2_by_endpoint.png", "mae_by_endpoint.png", "spearman_by_endpoint.png",
+        "overall_metrics.csv",
+        "predictions.parquet",
+        "best_params.csv",
+        "r2_by_endpoint.png",
+        "mae_by_endpoint.png",
+        "spearman_by_endpoint.png",
         "scatter_predictions.png",
     ]
     xgboost_dir = output_dir / "xgboost"
@@ -153,6 +165,7 @@ def _migrate_flat_outputs(output_dir: Path) -> None:
 
 
 # ── Figure generation ─────────────────────────────────────────────────────────
+
 
 def _generate_figures(
     pred_df: pd.DataFrame,
@@ -187,8 +200,17 @@ def _generate_figures(
         ci_hi = [metrics_df.loc[metrics_df["endpoint"] == ep, hi_col].values[0] for ep in active_endpoints]
         yerr = np.array([[v - lo, hi - v] for v, lo, hi in zip(vals, ci_lo, ci_hi)]).T
 
-        ax.bar(x, vals, width, color=model_color, edgecolor="white", alpha=0.8,
-               yerr=yerr, capsize=4, error_kw={"linewidth": 1.2})
+        ax.bar(
+            x,
+            vals,
+            width,
+            color=model_color,
+            edgecolor="white",
+            alpha=0.8,
+            yerr=yerr,
+            capsize=4,
+            error_kw={"linewidth": 1.2},
+        )
         ax.set_xticks(x)
         ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
         ax.set_ylabel(ylabel)
@@ -211,16 +233,22 @@ def _generate_figures(
     for ax_idx, ep in enumerate(active_endpoints):
         ax = axes[ax_idx]
         ep_pred = pred_df[pred_df["endpoint"] == ep]
-        ax.scatter(ep_pred["y_true"], ep_pred["y_pred"], s=5, alpha=0.3,
-                   color=model_color, rasterized=True)
+        ax.scatter(ep_pred["y_true"], ep_pred["y_pred"], s=5, alpha=0.3, color=model_color, rasterized=True)
 
         lo = min(ep_pred["y_true"].min(), ep_pred["y_pred"].min())
         hi = max(ep_pred["y_true"].max(), ep_pred["y_pred"].max())
         ax.plot([lo, hi], [lo, hi], "k--", alpha=0.3, linewidth=1)
 
         r2_val = metrics_df.loc[metrics_df["endpoint"] == ep, "r2"].values[0]
-        ax.text(0.05, 0.95, f"R²={r2_val:.3f}", transform=ax.transAxes,
-                fontsize=8, verticalalignment="top", color=model_color)
+        ax.text(
+            0.05,
+            0.95,
+            f"R²={r2_val:.3f}",
+            transform=ax.transAxes,
+            fontsize=8,
+            verticalalignment="top",
+            color=model_color,
+        )
 
         suffix = " (log)" if ep in LOG_TRANSFORM_ENDPOINTS else ""
         ax.set_xlabel(f"True{suffix}")
@@ -238,6 +266,7 @@ def _generate_figures(
 
 
 # ── Combined figures ──────────────────────────────────────────────────────────
+
 
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' metrics and produce side-by-side comparison figures."""
@@ -258,7 +287,8 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     # Comparison CSV
     merge_cols = ["endpoint", "mae", "r2", "spearman_r", "rae", "kendall_tau"]
     comparison_df = (
-        xgb[merge_cols].rename(columns={c: f"{c}_xgboost" for c in merge_cols if c != "endpoint"})
+        xgb[merge_cols]
+        .rename(columns={c: f"{c}_xgboost" for c in merge_cols if c != "endpoint"})
         .merge(
             chemprop[merge_cols].rename(columns={c: f"{c}_chemprop" for c in merge_cols if c != "endpoint"}),
             on="endpoint",
@@ -276,9 +306,13 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
         ("rae", "RAE", "rae_comparison"),
     ]:
         plot_model_comparison_bars(
-            data_by_model, "endpoint", metric, ylabel,
+            data_by_model,
+            "endpoint",
+            metric,
+            ylabel,
             f"{ylabel} — XGBoost vs Chemprop (original split)",
-            combined_dir / f"{fname}.png", dpi=dpi,
+            combined_dir / f"{fname}.png",
+            dpi=dpi,
         )
         logger.info(f"Saved {fname}.png")
 
@@ -287,11 +321,10 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
 
 # ── Main ─────────────────────────────────────────────────────────────────────
 
+
 @app.command()
 def main(
-    output_dir: Path = typer.Option(
-        PROCESSED_DATA_DIR / "2.08-seal-baseline-performance", help="Output directory"
-    ),
+    output_dir: Path = typer.Option(PROCESSED_DATA_DIR / "2.08-seal-baseline-performance", help="Output directory"),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
     combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
@@ -331,7 +364,6 @@ def main(
 
     train_smiles = train_df["SMILES"].tolist()
     test_smiles = test_df["SMILES"].tolist()
-    train_names = train_df["Molecule Name"].values
     test_names = test_df["Molecule Name"].values
 
     # ── 2. Protonate at each unique pH (both models use pH-appropriate SMILES) ──
@@ -404,7 +436,9 @@ def main(
             test_prot = [s for s, m in zip(prot_by_ph[ph]["test"], test_mask) if m]
             logger.info(f"  {ep} ({n_train} train, {n_test} test) — training Chemprop D-MPNN")
             y_pred = train_chemprop(
-                train_prot, y_tr, test_prot,
+                train_prot,
+                y_tr,
+                test_prot,
                 cache_dir=chemprop_cache,
                 cache_key=f"2.08_{ep}_baseline",
                 checkpoint_dir=model_dir / "models",
@@ -418,20 +452,31 @@ def main(
 
         logger.info(f"    MAE={mae:.3f}, R²={r2:.3f}, Spearman={sp_r:.3f}, RAE={rae:.3f}")
 
-        metric_rows.append({
-            "endpoint": ep, "ph": ph, "n_train": n_train, "n_test": n_test,
-            "mae": mae, "r2": r2, "spearman_r": sp_r, "kendall_tau": kt,
-            "rae": rae, "baseline_mad": baseline_mad,
-            "log_transformed": ep in LOG_TRANSFORM_ENDPOINTS,
-        })
+        metric_rows.append(
+            {
+                "endpoint": ep,
+                "ph": ph,
+                "n_train": n_train,
+                "n_test": n_test,
+                "mae": mae,
+                "r2": r2,
+                "spearman_r": sp_r,
+                "kendall_tau": kt,
+                "rae": rae,
+                "baseline_mad": baseline_mad,
+                "log_transformed": ep in LOG_TRANSFORM_ENDPOINTS,
+            }
+        )
 
         for j in range(len(y_te)):
-            prediction_rows.append({
-                "Molecule Name": te_names[j],
-                "endpoint": ep,
-                "y_true": float(y_te[j]),
-                "y_pred": float(y_pred[j]),
-            })
+            prediction_rows.append(
+                {
+                    "Molecule Name": te_names[j],
+                    "endpoint": ep,
+                    "y_true": float(y_te[j]),
+                    "y_pred": float(y_pred[j]),
+                }
+            )
 
     metrics_df = pd.DataFrame(metric_rows)
     logger.info(f"MA-RAE: {metrics_df['rae'].mean():.3f}")
@@ -458,13 +503,19 @@ def main(
             boot_sp.append(spearmanr(yt, yp).statistic)
             boot_rae.append(b_mae / baseline_mad if baseline_mad > 0 else np.nan)
 
-        boot_rows.append({
-            "endpoint": ep,
-            "mae_ci_lo": np.percentile(boot_mae, 2.5), "mae_ci_hi": np.percentile(boot_mae, 97.5),
-            "r2_ci_lo": np.percentile(boot_r2, 2.5), "r2_ci_hi": np.percentile(boot_r2, 97.5),
-            "spearman_ci_lo": np.percentile(boot_sp, 2.5), "spearman_ci_hi": np.percentile(boot_sp, 97.5),
-            "rae_ci_lo": np.percentile(boot_rae, 2.5), "rae_ci_hi": np.percentile(boot_rae, 97.5),
-        })
+        boot_rows.append(
+            {
+                "endpoint": ep,
+                "mae_ci_lo": np.percentile(boot_mae, 2.5),
+                "mae_ci_hi": np.percentile(boot_mae, 97.5),
+                "r2_ci_lo": np.percentile(boot_r2, 2.5),
+                "r2_ci_hi": np.percentile(boot_r2, 97.5),
+                "spearman_ci_lo": np.percentile(boot_sp, 2.5),
+                "spearman_ci_hi": np.percentile(boot_sp, 97.5),
+                "rae_ci_lo": np.percentile(boot_rae, 2.5),
+                "rae_ci_hi": np.percentile(boot_rae, 97.5),
+            }
+        )
         logger.info(
             f"  {ep}: R²=[{boot_rows[-1]['r2_ci_lo']:.3f}, {boot_rows[-1]['r2_ci_hi']:.3f}]  "
             f"RAE=[{boot_rows[-1]['rae_ci_lo']:.3f}, {boot_rows[-1]['rae_ci_hi']:.3f}]"

--- a/notebooks/2.09-seal-iid-vs-ood-series.py
+++ b/notebooks/2.09-seal-iid-vs-ood-series.py
@@ -3,25 +3,30 @@
 
 Takes two large Butina clusters (chemical series), time-splits the largest
 into train + IID validation, uses the smaller cluster as OOD test set, trains
-default XGBoost models, and compares squared error intra-series (IID) vs
-inter-series (OOD). Demonstrates that chemical series + time-split uniquely
-enable this analysis.
+XGBoost or Chemprop D-MPNN models, and compares squared error intra-series
+(IID) vs inter-series (OOD). Demonstrates that chemical series + time-split
+uniquely enable this analysis.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.09-seal-iid-vs-ood-series.py
+    pixi run -e cheminformatics python notebooks/2.09-seal-iid-vs-ood-series.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.09-seal-iid-vs-ood-series.py --combined
 
-Outputs:
-    data/processed/2.09-seal-iid-vs-ood-series/iid_vs_ood_errors.csv
-    data/processed/2.09-seal-iid-vs-ood-series/summary_metrics.csv
+Outputs (per model):
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/iid_vs_ood_errors.csv
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/summary_metrics.csv
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/squared_error_distributions.png
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/squared_error_distributions_v2.png
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/median_se_by_endpoint.png
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/mae_by_endpoint.png
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/r2_by_endpoint.png
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/spearman_by_endpoint.png
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/kendall_by_endpoint.png
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/rae_by_endpoint.png
+
+Model-agnostic outputs:
     data/processed/2.09-seal-iid-vs-ood-series/split_summary.csv
-    data/processed/2.09-seal-iid-vs-ood-series/squared_error_distributions.png
     data/processed/2.09-seal-iid-vs-ood-series/distance_characterization.png
-    data/processed/2.09-seal-iid-vs-ood-series/median_se_by_endpoint.png
-    data/processed/2.09-seal-iid-vs-ood-series/mae_by_endpoint.png
-    data/processed/2.09-seal-iid-vs-ood-series/r2_by_endpoint.png
-    data/processed/2.09-seal-iid-vs-ood-series/spearman_by_endpoint.png
-    data/processed/2.09-seal-iid-vs-ood-series/kendall_by_endpoint.png
-    data/processed/2.09-seal-iid-vs-ood-series/rae_by_endpoint.png
 """
 
 from pathlib import Path
@@ -40,9 +45,14 @@ from scipy.stats import kendalltau, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -189,6 +199,150 @@ def plot_squared_error_distributions(errors_df: pd.DataFrame, metrics_df: pd.Dat
     plt.close("all")
 
 
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move pre-model-flag XGBoost outputs into xgboost/ subdirectory."""
+    flat_files = [
+        "iid_vs_ood_errors.csv", "summary_metrics.csv",
+        "squared_error_distributions.png", "squared_error_distributions_v2.png",
+        "median_se_by_endpoint.png", "mae_by_endpoint.png", "r2_by_endpoint.png",
+        "spearman_by_endpoint.png", "kendall_by_endpoint.png", "rae_by_endpoint.png",
+    ]
+    xgboost_dir = output_dir / "xgboost"
+    migrated = []
+    for fname in flat_files:
+        src = output_dir / fname
+        dst = xgboost_dir / fname
+        if src.exists() and not dst.exists():
+            xgboost_dir.mkdir(parents=True, exist_ok=True)
+            src.rename(dst)
+            migrated.append(fname)
+    if migrated:
+        logger.info(f"Migrated {len(migrated)} existing files → xgboost/")
+
+
+def _generate_figures(errors_df: pd.DataFrame, metrics_df: pd.DataFrame,
+                      model_dir: Path, dpi: int) -> None:
+    """Generate all per-model figures."""
+    active_endpoints = sorted(metrics_df["endpoint"].unique())
+    n_ep = len(active_endpoints)
+
+    plot_squared_error_distributions(errors_df, metrics_df, model_dir, dpi)
+
+    # Figure A: Squared error distributions (3×3 grid)
+    nrows = (n_ep + 2) // 3
+    ncols = min(n_ep, 3)
+    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4 * nrows))
+    axes = np.atleast_2d(axes).ravel()
+
+    for ax_idx, ep in enumerate(active_endpoints):
+        ax = axes[ax_idx]
+        iid_se = errors_df[(errors_df["endpoint"] == ep) & (errors_df["set"] == "iid")]["squared_error"]
+        ood_se = errors_df[(errors_df["endpoint"] == ep) & (errors_df["set"] == "ood")]["squared_error"]
+
+        all_se = np.concatenate([iid_se.values, ood_se.values])
+        lo = max(all_se.min(), 1e-8)
+        hi = all_se.max()
+        bins = np.logspace(np.log10(lo), np.log10(hi), 40)
+
+        ax.hist(iid_se, bins=bins, density=True, alpha=0.6, color="steelblue",
+                label=f"IID (med={np.median(iid_se):.3f})", edgecolor="white")
+        ax.hist(ood_se, bins=bins, density=True, alpha=0.6, color="coral",
+                label=f"OOD (med={np.median(ood_se):.3f})", edgecolor="white")
+
+        ax.set_xscale("log")
+        ax.set_xlabel("Squared error")
+        ax.set_ylabel("Density")
+        ax.set_title(ep, fontsize=10, fontweight="bold")
+        ax.legend(fontsize=7)
+
+    for i in range(n_ep, len(axes)):
+        axes[i].set_visible(False)
+
+    fig.suptitle("IID vs OOD squared error distributions", fontsize=14, y=1.01)
+    fig.tight_layout()
+    fig.savefig(model_dir / "squared_error_distributions.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved squared_error_distributions.png")
+    plt.close("all")
+
+    # Figure B: Per-metric IID vs OOD bar charts
+    x = np.arange(len(active_endpoints))
+    width = 0.35
+
+    metric_plots = [
+        ("median_se", "Median squared error", "median_se"),
+        ("mae", "MAE", "mae"),
+        ("r2", "R²", "r2"),
+        ("spearman_r", "Spearman ρ", "spearman"),
+        ("kendall_tau", "Kendall τ", "kendall"),
+        ("rae", "RAE", "rae"),
+    ]
+
+    for col, ylabel, fname in metric_plots:
+        fig, ax = plt.subplots(figsize=(10, 5))
+
+        iid_vals = []
+        ood_vals = []
+        for ep in active_endpoints:
+            iid_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "iid")]
+            ood_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "ood")]
+            iid_vals.append(iid_row[col].values[0])
+            ood_vals.append(ood_row[col].values[0])
+
+        ax.bar(x - width / 2, iid_vals, width, label="IID",
+               color="steelblue", edgecolor="white", alpha=0.8)
+        ax.bar(x + width / 2, ood_vals, width, label="OOD",
+               color="coral", edgecolor="white", alpha=0.8)
+
+        ax.set_xticks(x)
+        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
+        ax.set_ylabel(ylabel)
+        ax.set_title(f"IID vs OOD {ylabel} by endpoint")
+        ax.legend()
+        if col in ("r2",):
+            ax.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(model_dir / f"{fname}_by_endpoint.png", dpi=dpi, bbox_inches="tight")
+        logger.info(f"Saved {fname}_by_endpoint.png")
+        plt.close("all")
+
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Load both models' metrics and produce side-by-side comparison figures."""
+    xgb_path = output_dir / "xgboost" / "summary_metrics.csv"
+    chemprop_path = output_dir / "chemprop" / "summary_metrics.csv"
+
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    if missing:
+        logger.error(f"Missing results for: {missing}. Run those models first.")
+        return
+
+    combined_dir = output_dir / "combined"
+    combined_dir.mkdir(parents=True, exist_ok=True)
+
+    xgb = pd.read_csv(xgb_path)
+    chemprop = pd.read_csv(chemprop_path)
+
+    for set_label in ("iid", "ood"):
+        xgb_set = xgb[xgb["set"] == set_label].copy()
+        chemprop_set = chemprop[chemprop["set"] == set_label].copy()
+        data_by_model = {"xgboost": xgb_set, "chemprop": chemprop_set}
+
+        for metric, ylabel, fname in [
+            ("mae", "MAE", "mae"),
+            ("r2", "R²", "r2"),
+            ("spearman_r", "Spearman ρ", "spearman"),
+            ("rae", "RAE", "rae"),
+        ]:
+            plot_model_comparison_bars(
+                data_by_model, "endpoint", metric, ylabel,
+                f"{ylabel} — XGBoost vs Chemprop ({set_label.upper()})",
+                combined_dir / f"{fname}_{set_label}_comparison.png", dpi=dpi,
+            )
+            logger.info(f"Saved {fname}_{set_label}_comparison.png")
+
+    logger.info(f"Combined figures saved to {combined_dir}")
+
+
 @app.command()
 def main(
     output_dir: Path = typer.Option(
@@ -196,17 +350,33 @@ def main(
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     train_frac: float = typer.Option(0.8, help="Fraction of largest cluster for training (rest = IID val)"),
-    figures_only: bool = typer.Option(False, help="Regenerate figures from existing data without retraining"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # ── Figures-only mode ─────────────────────────────────────────────
-    if figures_only:
-        logger.info("Figures-only mode: loading existing data")
-        errors_df = pd.read_csv(output_dir / "iid_vs_ood_errors.csv")
-        metrics_df = pd.read_csv(output_dir / "summary_metrics.csv")
-        plot_squared_error_distributions(errors_df, metrics_df, output_dir, dpi)
+    if combined:
+        _generate_combined_figures(output_dir, dpi)
+        return
+
+    if model not in ("xgboost", "chemprop"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+        raise typer.Exit(1)
+
+    _migrate_flat_outputs(output_dir)
+
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # Skip training if outputs already exist
+    errors_path = model_dir / "iid_vs_ood_errors.csv"
+    metrics_path = model_dir / "summary_metrics.csv"
+    if errors_path.exists() and metrics_path.exists():
+        logger.info(f"Existing {model} outputs found — regenerating figures only")
+        errors_df = pd.read_csv(errors_path)
+        metrics_df = pd.read_csv(metrics_path)
+        _generate_figures(errors_df, metrics_df, model_dir, dpi)
         logger.info("Figures regenerated (no models retrained)")
         return
 
@@ -265,7 +435,7 @@ def main(
 
     logger.info(f"IID 1-NN median: {np.median(iid_nn1):.3f}, OOD 1-NN median: {np.median(ood_nn1):.3f}")
 
-    # Save split summary
+    # Save split summary (model-agnostic)
     split_summary = pd.DataFrame([
         {"set": "train", "n": len(train_df), "cluster_id": int(largest_cid)},
         {"set": "iid", "n": len(iid_df), "cluster_id": int(largest_cid),
@@ -276,49 +446,70 @@ def main(
     split_summary.to_csv(output_dir / "split_summary.csv", index=False)
     logger.info("Saved split_summary.csv")
 
-    # ── 5. Train XGBoost per endpoint and collect errors ──────────────
-    error_rows = []
-    metric_rows = []
+    # Distance characterization figure (model-agnostic)
+    fig, ax = plt.subplots(figsize=(8, 5))
+    bins = np.linspace(0, 1, 51)
+    ax.hist(iid_nn1, bins=bins, density=True, alpha=0.6, color="steelblue",
+            label=f"IID (med={np.median(iid_nn1):.3f})", edgecolor="white")
+    ax.hist(ood_nn1, bins=bins, density=True, alpha=0.6, color="coral",
+            label=f"OOD (med={np.median(ood_nn1):.3f})", edgecolor="white")
+    ax.set_xlabel("Test-to-train 1-NN Tanimoto distance")
+    ax.set_ylabel("Density")
+    ax.set_title("Structural distance to training set: IID vs OOD")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(output_dir / "distance_characterization.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved distance_characterization.png")
+    plt.close("all")
 
-    # Precompute features per pH (protonation differs by pH)
+    # ── 5. Protonation and featurization ─────────────────────────────
     unique_phs = sorted(set(ENDPOINT_PH.values()))
     features_cache: dict[float, dict[str, tuple]] = {}
+    prot_cache: dict[float, dict[str, list[str]]] = {}
 
     for ph in unique_phs:
-        logger.info(f"Protonating and featurizing at pH {ph}")
+        logger.info(f"Protonating at pH {ph}")
         train_prot = protonate_at_ph(train_df["SMILES"].tolist(), ph)
         iid_prot = protonate_at_ph(iid_df["SMILES"].tolist(), ph)
         ood_prot = protonate_at_ph(ood_df["SMILES"].tolist(), ph)
 
-        ecfp_tr, desc_tr = compute_features(train_prot)
-        ecfp_iid, desc_iid = compute_features(iid_prot)
-        ecfp_ood, desc_ood = compute_features(ood_prot)
+        prot_cache[ph] = {"train": train_prot, "iid": iid_prot, "ood": ood_prot}
 
-        # Remove zero-variance descriptors (fit on train)
-        variance = desc_tr.var(axis=0)
-        nonzero_var = variance > 0
-        desc_tr = desc_tr[:, nonzero_var]
-        desc_iid = desc_iid[:, nonzero_var]
-        desc_ood = desc_ood[:, nonzero_var]
+        if model == "xgboost":
+            logger.info(f"Computing XGBoost features at pH {ph}")
+            ecfp_tr, desc_tr = compute_features(train_prot)
+            ecfp_iid, desc_iid = compute_features(iid_prot)
+            ecfp_ood, desc_ood = compute_features(ood_prot)
 
-        # Scale descriptors
-        scaler = StandardScaler()
-        desc_tr_scaled = scaler.fit_transform(desc_tr)
-        desc_iid_scaled = scaler.transform(desc_iid)
-        desc_ood_scaled = scaler.transform(desc_ood)
+            # Remove zero-variance descriptors (fit on train)
+            variance = desc_tr.var(axis=0)
+            nonzero_var = variance > 0
+            desc_tr = desc_tr[:, nonzero_var]
+            desc_iid = desc_iid[:, nonzero_var]
+            desc_ood = desc_ood[:, nonzero_var]
 
-        features_cache[ph] = {
-            "train": (ecfp_tr, desc_tr_scaled),
-            "iid": (ecfp_iid, desc_iid_scaled),
-            "ood": (ecfp_ood, desc_ood_scaled),
-        }
-        logger.info(f"  pH {ph}: {ecfp_tr.shape[1] + desc_tr.shape[1]} features")
+            # Scale descriptors
+            scaler = StandardScaler()
+            desc_tr_scaled = scaler.fit_transform(desc_tr)
+            desc_iid_scaled = scaler.transform(desc_iid)
+            desc_ood_scaled = scaler.transform(desc_ood)
+
+            features_cache[ph] = {
+                "train": (ecfp_tr, desc_tr_scaled),
+                "iid": (ecfp_iid, desc_iid_scaled),
+                "ood": (ecfp_ood, desc_ood_scaled),
+            }
+            logger.info(f"  pH {ph}: {ecfp_tr.shape[1] + desc_tr_scaled.shape[1]} features")
+
+    # ── 6. Train model per endpoint and collect errors ────────────────
+    error_rows = []
+    metric_rows = []
+
+    optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
+    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
 
     for ep in ENDPOINTS:
         ph = ENDPOINT_PH[ep]
-        ecfp_tr, desc_tr = features_cache[ph]["train"]
-        ecfp_iid, desc_iid = features_cache[ph]["iid"]
-        ecfp_ood, desc_ood = features_cache[ph]["ood"]
 
         # Masks for non-null endpoint values
         train_mask = train_df[ep].notna().values
@@ -332,10 +523,6 @@ def main(
         if n_tr < 20 or n_iid < 10 or n_ood < 10:
             logger.warning(f"Skipping {ep}: insufficient data (train={n_tr}, iid={n_iid}, ood={n_ood})")
             continue
-
-        X_tr = np.hstack([ecfp_tr[train_mask], desc_tr[train_mask]])
-        X_iid = np.hstack([ecfp_iid[iid_mask], desc_iid[iid_mask]])
-        X_ood = np.hstack([ecfp_ood[ood_mask], desc_ood[ood_mask]])
 
         y_tr_raw = train_df[ep].values[train_mask]
         y_iid_raw = iid_df[ep].values[iid_mask]
@@ -352,11 +539,37 @@ def main(
 
         logger.info(f"  {ep}: train={n_tr}, iid={n_iid}, ood={n_ood}")
 
-        cache_dir = INTERIM_DATA_DIR / "optuna_cache"
-        model, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_iid_ood")
+        if model == "xgboost":
+            ecfp_tr, desc_tr = features_cache[ph]["train"]
+            ecfp_iid, desc_iid = features_cache[ph]["iid"]
+            ecfp_ood, desc_ood = features_cache[ph]["ood"]
 
-        y_pred_iid = model.predict(X_iid)
-        y_pred_ood = model.predict(X_ood)
+            X_tr = np.hstack([ecfp_tr[train_mask], desc_tr[train_mask]])
+            X_iid = np.hstack([ecfp_iid[iid_mask], desc_iid[iid_mask]])
+            X_ood = np.hstack([ecfp_ood[ood_mask], desc_ood[ood_mask]])
+
+            model_obj, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=optuna_cache, cache_key=f"{ep}_iid_ood")
+            y_pred_iid = model_obj.predict(X_iid)
+            y_pred_ood = model_obj.predict(X_ood)
+        else:
+            all_train_prot = prot_cache[ph]["train"]
+            all_iid_prot = prot_cache[ph]["iid"]
+            all_ood_prot = prot_cache[ph]["ood"]
+
+            train_prot = [all_train_prot[i] for i in np.where(train_mask)[0]]
+            iid_prot = [all_iid_prot[i] for i in np.where(iid_mask)[0]]
+            ood_prot = [all_ood_prot[i] for i in np.where(ood_mask)[0]]
+
+            y_pred_iid = train_chemprop(
+                train_prot, y_tr, iid_prot,
+                cache_dir=chemprop_cache,
+                cache_key=f"2.09_{ep}_iid_ood_iid",
+            )
+            y_pred_ood = train_chemprop(
+                train_prot, y_tr, ood_prot,
+                cache_dir=chemprop_cache,
+                cache_key=f"2.09_{ep}_iid_ood_ood",
+            )
 
         se_iid = (y_iid - y_pred_iid) ** 2
         se_ood = (y_ood - y_pred_ood) ** 2
@@ -402,107 +615,13 @@ def main(
     errors_df = pd.DataFrame(error_rows)
     metrics_df = pd.DataFrame(metric_rows)
 
-    errors_df.to_csv(output_dir / "iid_vs_ood_errors.csv", index=False)
-    metrics_df.to_csv(output_dir / "summary_metrics.csv", index=False)
+    errors_df.to_csv(errors_path, index=False)
+    metrics_df.to_csv(metrics_path, index=False)
     logger.info("Saved iid_vs_ood_errors.csv and summary_metrics.csv")
 
-    # ── 6. Figure A: Squared error distributions (3×3 grid) ───────────
-    active_endpoints = sorted(metrics_df["endpoint"].unique())
-    n_ep = len(active_endpoints)
-    nrows = (n_ep + 2) // 3
-    ncols = min(n_ep, 3)
-    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4 * nrows))
-    axes = np.atleast_2d(axes).ravel()
-
-    for ax_idx, ep in enumerate(active_endpoints):
-        ax = axes[ax_idx]
-        iid_se = errors_df[(errors_df["endpoint"] == ep) & (errors_df["set"] == "iid")]["squared_error"]
-        ood_se = errors_df[(errors_df["endpoint"] == ep) & (errors_df["set"] == "ood")]["squared_error"]
-
-        # Use log-scale bins for squared errors
-        all_se = np.concatenate([iid_se.values, ood_se.values])
-        lo = max(all_se.min(), 1e-8)
-        hi = all_se.max()
-        bins = np.logspace(np.log10(lo), np.log10(hi), 40)
-
-        ax.hist(iid_se, bins=bins, density=True, alpha=0.6, color="steelblue",
-                label=f"IID (med={np.median(iid_se):.3f})", edgecolor="white")
-        ax.hist(ood_se, bins=bins, density=True, alpha=0.6, color="coral",
-                label=f"OOD (med={np.median(ood_se):.3f})", edgecolor="white")
-
-        ax.set_xscale("log")
-        ax.set_xlabel("Squared error")
-        ax.set_ylabel("Density")
-        ax.set_title(ep, fontsize=10, fontweight="bold")
-        ax.legend(fontsize=7)
-
-    for i in range(n_ep, len(axes)):
-        axes[i].set_visible(False)
-
-    fig.suptitle("IID vs OOD squared error distributions", fontsize=14, y=1.01)
-    fig.tight_layout()
-    fig.savefig(output_dir / "squared_error_distributions.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved squared_error_distributions.png")
-    plt.close("all")
-
-    # ── 7. Figure B: Distance characterization ────────────────────────
-    fig, ax = plt.subplots(figsize=(8, 5))
-    bins = np.linspace(0, 1, 51)
-    ax.hist(iid_nn1, bins=bins, density=True, alpha=0.6, color="steelblue",
-            label=f"IID (med={np.median(iid_nn1):.3f})", edgecolor="white")
-    ax.hist(ood_nn1, bins=bins, density=True, alpha=0.6, color="coral",
-            label=f"OOD (med={np.median(ood_nn1):.3f})", edgecolor="white")
-    ax.set_xlabel("Test-to-train 1-NN Tanimoto distance")
-    ax.set_ylabel("Density")
-    ax.set_title("Structural distance to training set: IID vs OOD")
-    ax.legend()
-    fig.tight_layout()
-    fig.savefig(output_dir / "distance_characterization.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved distance_characterization.png")
-    plt.close("all")
-
-    # ── 8. Figure C: Per-metric IID vs OOD bar charts ───────────────
-    x = np.arange(len(active_endpoints))
-    width = 0.35
-
-    metric_plots = [
-        ("median_se", "Median squared error", "median_se"),
-        ("mae", "MAE", "mae"),
-        ("r2", "R²", "r2"),
-        ("spearman_r", "Spearman ρ", "spearman"),
-        ("kendall_tau", "Kendall τ", "kendall"),
-        ("rae", "RAE", "rae"),
-    ]
-
-    for col, ylabel, fname in metric_plots:
-        fig, ax = plt.subplots(figsize=(10, 5))
-
-        iid_vals = []
-        ood_vals = []
-        for ep in active_endpoints:
-            iid_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "iid")]
-            ood_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "ood")]
-            iid_vals.append(iid_row[col].values[0])
-            ood_vals.append(ood_row[col].values[0])
-
-        ax.bar(x - width / 2, iid_vals, width, label="IID",
-               color="steelblue", edgecolor="white", alpha=0.8)
-        ax.bar(x + width / 2, ood_vals, width, label="OOD",
-               color="coral", edgecolor="white", alpha=0.8)
-
-        ax.set_xticks(x)
-        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
-        ax.set_ylabel(ylabel)
-        ax.set_title(f"IID vs OOD {ylabel} by endpoint")
-        ax.legend()
-        if col in ("r2",):
-            ax.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
-        fig.tight_layout()
-        fig.savefig(output_dir / f"{fname}_by_endpoint.png", dpi=dpi, bbox_inches="tight")
-        logger.info(f"Saved {fname}_by_endpoint.png")
-        plt.close("all")
-
-    logger.info(f"All outputs saved to {output_dir}")
+    # ── 7. Figures ────────────────────────────────────────────────────
+    _generate_figures(errors_df, metrics_df, model_dir, dpi)
+    logger.info(f"All outputs saved to {model_dir}")
 
 
 if __name__ == "__main__":

--- a/notebooks/2.09-seal-iid-vs-ood-series.py
+++ b/notebooks/2.09-seal-iid-vs-ood-series.py
@@ -564,11 +564,13 @@ def main(
                 train_prot, y_tr, iid_prot,
                 cache_dir=chemprop_cache,
                 cache_key=f"2.09_{ep}_iid_ood_iid",
+                checkpoint_dir=model_dir / "models",
             )
             y_pred_ood = train_chemprop(
                 train_prot, y_tr, ood_prot,
                 cache_dir=chemprop_cache,
                 cache_key=f"2.09_{ep}_iid_ood_ood",
+                checkpoint_dir=model_dir / "models",
             )
 
         se_iid = (y_iid - y_pred_iid) ** 2

--- a/notebooks/2.10-seal-activity-cliff-eval.py
+++ b/notebooks/2.10-seal-activity-cliff-eval.py
@@ -554,6 +554,7 @@ def main(
                     train_prot, y_tr, test_prot,
                     cache_dir=chemprop_cache,
                     cache_key=f"2.10_{ep}_cluster_fold{fold_id}",
+                    checkpoint_dir=model_dir / "models",
                 )
 
             se = (y_te - y_pred) ** 2

--- a/notebooks/2.10-seal-activity-cliff-eval.py
+++ b/notebooks/2.10-seal-activity-cliff-eval.py
@@ -2,26 +2,30 @@
 """Activity cliff evaluation (paper Fig S3, ref: MoleculeACE).
 
 Identifies activity cliffs — pairs of structurally similar molecules with large
-activity differences — and evaluates XGBoost performance on cliff vs non-cliff
-molecules. Uses cluster-split CV (repeat 0, 5 folds) to train and evaluate.
-Demonstrates that smoothly interpolating models fail on activity cliffs.
+activity differences — and evaluates XGBoost or Chemprop D-MPNN performance on
+cliff vs non-cliff molecules. Uses cluster-split CV (repeat 0, 5 folds) to train
+and evaluate. Demonstrates that smoothly interpolating models fail on activity cliffs.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py
+    pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py --combined
 
-Outputs:
+Model-agnostic outputs:
     data/processed/2.10-seal-activity-cliff-eval/cliff_stats.csv
     data/processed/2.10-seal-activity-cliff-eval/cliff_molecules.csv
-    data/processed/2.10-seal-activity-cliff-eval/cliff_vs_noncliff_errors.csv
-    data/processed/2.10-seal-activity-cliff-eval/summary_metrics.csv
-    data/processed/2.10-seal-activity-cliff-eval/squared_error_distributions.png
     data/processed/2.10-seal-activity-cliff-eval/cliff_characterization.png
-    data/processed/2.10-seal-activity-cliff-eval/median_se_by_endpoint.png
-    data/processed/2.10-seal-activity-cliff-eval/mae_by_endpoint.png
-    data/processed/2.10-seal-activity-cliff-eval/r2_by_endpoint.png
-    data/processed/2.10-seal-activity-cliff-eval/spearman_by_endpoint.png
-    data/processed/2.10-seal-activity-cliff-eval/kendall_by_endpoint.png
-    data/processed/2.10-seal-activity-cliff-eval/rae_by_endpoint.png
+
+Outputs (per model):
+    data/processed/2.10-seal-activity-cliff-eval/{model}/cliff_vs_noncliff_errors.csv
+    data/processed/2.10-seal-activity-cliff-eval/{model}/summary_metrics.csv
+    data/processed/2.10-seal-activity-cliff-eval/{model}/squared_error_distributions.png
+    data/processed/2.10-seal-activity-cliff-eval/{model}/median_se_by_endpoint.png
+    data/processed/2.10-seal-activity-cliff-eval/{model}/mae_by_endpoint.png
+    data/processed/2.10-seal-activity-cliff-eval/{model}/r2_by_endpoint.png
+    data/processed/2.10-seal-activity-cliff-eval/{model}/spearman_by_endpoint.png
+    data/processed/2.10-seal-activity-cliff-eval/{model}/kendall_by_endpoint.png
+    data/processed/2.10-seal-activity-cliff-eval/{model}/rae_by_endpoint.png
 """
 
 from pathlib import Path
@@ -40,9 +44,14 @@ from scipy.stats import kendalltau, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -171,6 +180,153 @@ def identify_cliffs(
     return cliff_indices, cliff_pairs, diff_threshold
 
 
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move pre-model-flag XGBoost outputs into xgboost/ subdirectory."""
+    flat_files = [
+        "cliff_vs_noncliff_errors.csv", "summary_metrics.csv",
+        "squared_error_distributions.png",
+        "median_se_by_endpoint.png", "mae_by_endpoint.png", "r2_by_endpoint.png",
+        "spearman_by_endpoint.png", "kendall_by_endpoint.png", "rae_by_endpoint.png",
+    ]
+    xgboost_dir = output_dir / "xgboost"
+    migrated = []
+    for fname in flat_files:
+        src = output_dir / fname
+        dst = xgboost_dir / fname
+        if src.exists() and not dst.exists():
+            xgboost_dir.mkdir(parents=True, exist_ok=True)
+            src.rename(dst)
+            migrated.append(fname)
+    if migrated:
+        logger.info(f"Migrated {len(migrated)} existing files → xgboost/")
+
+
+def _generate_figures(errors_df: pd.DataFrame, metrics_df: pd.DataFrame,
+                      model_dir: Path, dpi: int) -> None:
+    """Generate all per-model figures."""
+    active_endpoints = sorted(metrics_df["endpoint"].unique())
+    n_ep = len(active_endpoints)
+
+    # Figure A: Squared error distributions (3×3 grid)
+    nrows = (n_ep + 2) // 3
+    ncols = min(n_ep, 3)
+    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4 * nrows))
+    axes = np.atleast_2d(axes).ravel()
+
+    for ax_idx, ep in enumerate(active_endpoints):
+        ax = axes[ax_idx]
+        cliff_se = errors_df[(errors_df["endpoint"] == ep) & (errors_df["is_cliff"])]["squared_error"]
+        noncliff_se = errors_df[(errors_df["endpoint"] == ep) & (~errors_df["is_cliff"])]["squared_error"]
+
+        if cliff_se.empty or noncliff_se.empty:
+            ax.set_visible(False)
+            continue
+
+        all_se = np.concatenate([cliff_se.values, noncliff_se.values])
+        lo = max(all_se.min(), 1e-8)
+        hi = all_se.max()
+        bins = np.logspace(np.log10(lo), np.log10(hi), 40)
+
+        ax.hist(noncliff_se, bins=bins, density=True, alpha=0.6, color="steelblue",
+                label=f"Non-cliff (med={np.median(noncliff_se):.3f})", edgecolor="white")
+        ax.hist(cliff_se, bins=bins, density=True, alpha=0.6, color="coral",
+                label=f"Cliff (med={np.median(cliff_se):.3f})", edgecolor="white")
+
+        ax.set_xscale("log")
+        ax.set_xlabel("Squared error")
+        ax.set_ylabel("Density")
+        ax.set_title(ep, fontsize=10, fontweight="bold")
+        ax.legend(fontsize=7)
+
+    for i in range(n_ep, len(axes)):
+        axes[i].set_visible(False)
+
+    fig.suptitle("Cliff vs non-cliff squared error distributions", fontsize=14, y=1.01)
+    fig.tight_layout()
+    fig.savefig(model_dir / "squared_error_distributions.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved squared_error_distributions.png")
+    plt.close("all")
+
+    # Figure B: Per-metric bar charts
+    x = np.arange(len(active_endpoints))
+    width = 0.35
+
+    metric_plots = [
+        ("median_se", "Median squared error", "median_se"),
+        ("mae", "MAE", "mae"),
+        ("r2", "R²", "r2"),
+        ("spearman_r", "Spearman ρ", "spearman"),
+        ("kendall_tau", "Kendall τ", "kendall"),
+        ("rae", "RAE", "rae"),
+    ]
+
+    for col, ylabel, fname in metric_plots:
+        fig, ax = plt.subplots(figsize=(10, 5))
+
+        cliff_vals = []
+        noncliff_vals = []
+        for ep in active_endpoints:
+            cliff_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "cliff")]
+            noncliff_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "non-cliff")]
+            cliff_vals.append(cliff_row[col].values[0] if not cliff_row.empty else np.nan)
+            noncliff_vals.append(noncliff_row[col].values[0] if not noncliff_row.empty else np.nan)
+
+        ax.bar(x - width / 2, noncliff_vals, width, label="Non-cliff",
+               color="steelblue", edgecolor="white", alpha=0.8)
+        ax.bar(x + width / 2, cliff_vals, width, label="Cliff",
+               color="coral", edgecolor="white", alpha=0.8)
+
+        ax.set_xticks(x)
+        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
+        ax.set_ylabel(ylabel)
+        ax.set_title(f"Cliff vs non-cliff {ylabel} by endpoint")
+        ax.legend()
+        if col in ("r2",):
+            ax.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
+        fig.tight_layout()
+        fig.savefig(model_dir / f"{fname}_by_endpoint.png", dpi=dpi, bbox_inches="tight")
+        logger.info(f"Saved {fname}_by_endpoint.png")
+        plt.close("all")
+
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Load both models' metrics and produce side-by-side comparison figures."""
+    xgb_path = output_dir / "xgboost" / "summary_metrics.csv"
+    chemprop_path = output_dir / "chemprop" / "summary_metrics.csv"
+
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    if missing:
+        logger.error(f"Missing results for: {missing}. Run those models first.")
+        return
+
+    combined_dir = output_dir / "combined"
+    combined_dir.mkdir(parents=True, exist_ok=True)
+
+    xgb = pd.read_csv(xgb_path)
+    chemprop = pd.read_csv(chemprop_path)
+
+    for set_label in ("cliff", "non-cliff"):
+        xgb_set = xgb[xgb["set"] == set_label].copy()
+        chemprop_set = chemprop[chemprop["set"] == set_label].copy()
+        data_by_model = {"xgboost": xgb_set, "chemprop": chemprop_set}
+
+        fname_label = set_label.replace("-", "")
+        for metric, ylabel, fname in [
+            ("mae", "MAE", "mae"),
+            ("r2", "R²", "r2"),
+            ("spearman_r", "Spearman ρ", "spearman"),
+            ("rae", "RAE", "rae"),
+        ]:
+            plot_model_comparison_bars(
+                data_by_model, "endpoint", metric, ylabel,
+                f"{ylabel} — XGBoost vs Chemprop ({set_label})",
+                combined_dir / f"{fname}_{fname_label}_comparison.png", dpi=dpi,
+            )
+            logger.info(f"Saved {fname}_{fname_label}_comparison.png")
+
+    logger.info(f"Combined figures saved to {combined_dir}")
+
+
 @app.command()
 def main(
     output_dir: Path = typer.Option(
@@ -179,9 +335,24 @@ def main(
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     sim_threshold: float = typer.Option(0.85, help="Tanimoto similarity threshold for similar pairs"),
     min_diff: float = typer.Option(1.0, help="Absolute activity difference threshold for cliff definition"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if combined:
+        _generate_combined_figures(output_dir, dpi)
+        return
+
+    if model not in ("xgboost", "chemprop"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+        raise typer.Exit(1)
+
+    _migrate_flat_outputs(output_dir)
+
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
 
     # ── 1. Load data ──────────────────────────────────────────────────
     logger.info("Loading canonical dataset")
@@ -269,9 +440,50 @@ def main(
     cliff_mol_df.to_csv(output_dir / "cliff_molecules.csv", index=False)
     logger.info(f"Saved cliff_molecules.csv ({len(cliff_mol_df)} rows)")
 
-    # ── 3. Train XGBoost with cluster-split CV and evaluate ───────────
+    # Cliff characterization figure (model-agnostic)
+    ep_order = cliff_stats_df.sort_values("pct_cliff", ascending=False)["endpoint"]
+    x = np.arange(len(ep_order))
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+    ax = axes[0]
+    pcts = [cliff_stats_df[cliff_stats_df["endpoint"] == ep]["pct_cliff"].values[0] for ep in ep_order]
+    ax.bar(x, pcts, color="coral", edgecolor="white", alpha=0.8)
+    ax.set_xticks(x)
+    ax.set_xticklabels(ep_order, rotation=45, ha="right", fontsize=8)
+    ax.set_ylabel("% cliff molecules")
+    ax.set_title(f"Activity cliff prevalence (sim>{sim_threshold})")
+
+    ax = axes[1]
+    ax.bar(x, [cliff_stats_df[cliff_stats_df["endpoint"] == ep]["n_cliff_pairs"].values[0] for ep in ep_order],
+           color="coral", edgecolor="white", alpha=0.8, label="Cliff pairs")
+    ax.set_xticks(x)
+    ax.set_xticklabels(ep_order, rotation=45, ha="right", fontsize=8)
+    ax.set_ylabel("Number of cliff pairs")
+    ax.set_title("Cliff pair counts per endpoint")
+
+    fig.tight_layout()
+    fig.savefig(output_dir / "cliff_characterization.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved cliff_characterization.png")
+    plt.close("all")
+
+    # Skip training if outputs already exist
+    errors_path = model_dir / "cliff_vs_noncliff_errors.csv"
+    metrics_path = model_dir / "summary_metrics.csv"
+    if errors_path.exists() and metrics_path.exists():
+        logger.info(f"Existing {model} outputs found — regenerating figures only")
+        errors_df = pd.read_csv(errors_path)
+        metrics_df = pd.read_csv(metrics_path)
+        _generate_figures(errors_df, metrics_df, model_dir, dpi)
+        logger.info("Figures regenerated (no models retrained)")
+        return
+
+    # ── 3. Train model with cluster-split CV and evaluate ─────────────
     error_rows = []
     metric_rows = []
+
+    optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
+    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
 
     for ep in ENDPOINTS:
         ph = ENDPOINT_PH[ep]
@@ -290,21 +502,6 @@ def main(
             logger.warning(f"Skipping {ep}: not enough folds")
             continue
 
-        # Compute features once for this endpoint
-        smiles = ep_df["SMILES"].tolist()
-        prot_smiles = protonate_at_ph(smiles, ph)
-        ecfp, desc = compute_features(prot_smiles)
-
-        # Remove zero-variance descriptors
-        variance = desc.var(axis=0)
-        nonzero_var = variance > 0
-        desc = desc[:, nonzero_var]
-
-        # Scale descriptors
-        scaler = StandardScaler()
-        desc_scaled = scaler.fit_transform(desc)
-        X_all = np.hstack([ecfp, desc_scaled])
-
         # Activity values
         raw_values = ep_df[ep].values
         if ep in LOG_TRANSFORM_ENDPOINTS:
@@ -312,24 +509,52 @@ def main(
         else:
             y_all = raw_values
 
+        # Compute features once for this endpoint (XGBoost only)
+        if model == "xgboost":
+            smiles = ep_df["SMILES"].tolist()
+            prot_smiles = protonate_at_ph(smiles, ph)
+            ecfp, desc = compute_features(prot_smiles)
+
+            # Remove zero-variance descriptors
+            variance = desc.var(axis=0)
+            nonzero_var = variance > 0
+            desc = desc[:, nonzero_var]
+
+            # Scale descriptors
+            scaler = StandardScaler()
+            desc_scaled = scaler.fit_transform(desc)
+            X_all = np.hstack([ecfp, desc_scaled])
+        else:
+            smiles = ep_df["SMILES"].tolist()
+            all_prot = protonate_at_ph(smiles, ph)
+
         logger.info(f"  {ep}: {len(unique_folds)} folds, {len(cliff_name_set)} cliff molecules")
 
         for fold_id in unique_folds:
             test_mask = fold_ids == fold_id
             train_mask = (fold_ids >= 0) & ~test_mask
 
-            X_tr = X_all[train_mask]
             y_tr = y_all[train_mask]
-            X_te = X_all[test_mask]
             y_te = y_all[test_mask]
             te_names = names[test_mask]
 
             if len(y_te) < 10:
                 continue
 
-            cache_dir = INTERIM_DATA_DIR / "optuna_cache"
-            model, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_cluster_fold{fold_id}")
-            y_pred = model.predict(X_te)
+            if model == "xgboost":
+                X_tr = X_all[train_mask]
+                X_te = X_all[test_mask]
+                model_obj, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=optuna_cache,
+                                               cache_key=f"{ep}_cluster_fold{fold_id}")
+                y_pred = model_obj.predict(X_te)
+            else:
+                train_prot = [all_prot[i] for i in np.where(train_mask)[0]]
+                test_prot = [all_prot[i] for i in np.where(test_mask)[0]]
+                y_pred = train_chemprop(
+                    train_prot, y_tr, test_prot,
+                    cache_dir=chemprop_cache,
+                    cache_key=f"2.10_{ep}_cluster_fold{fold_id}",
+                )
 
             se = (y_te - y_pred) ** 2
             is_cliff = np.array([n in cliff_name_set for n in te_names])
@@ -346,7 +571,7 @@ def main(
                 })
 
     errors_df = pd.DataFrame(error_rows)
-    errors_df.to_csv(output_dir / "cliff_vs_noncliff_errors.csv", index=False)
+    errors_df.to_csv(errors_path, index=False)
     logger.info(f"Saved cliff_vs_noncliff_errors.csv ({len(errors_df)} rows)")
 
     # ── 4. Aggregate metrics: cliff vs non-cliff ──────────────────────
@@ -392,121 +617,12 @@ def main(
             })
 
     metrics_df = pd.DataFrame(metric_rows)
-    metrics_df.to_csv(output_dir / "summary_metrics.csv", index=False)
+    metrics_df.to_csv(metrics_path, index=False)
     logger.info("Saved summary_metrics.csv")
 
-    # ── 5. Figure A: Squared error distributions (3×3 grid) ───────────
-    active_endpoints = sorted(metrics_df["endpoint"].unique())
-    n_ep = len(active_endpoints)
-    nrows = (n_ep + 2) // 3
-    ncols = min(n_ep, 3)
-    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4 * nrows))
-    axes = np.atleast_2d(axes).ravel()
-
-    for ax_idx, ep in enumerate(active_endpoints):
-        ax = axes[ax_idx]
-        cliff_se = errors_df[(errors_df["endpoint"] == ep) & (errors_df["is_cliff"])]["squared_error"]
-        noncliff_se = errors_df[(errors_df["endpoint"] == ep) & (~errors_df["is_cliff"])]["squared_error"]
-
-        if cliff_se.empty or noncliff_se.empty:
-            ax.set_visible(False)
-            continue
-
-        all_se = np.concatenate([cliff_se.values, noncliff_se.values])
-        lo = max(all_se.min(), 1e-8)
-        hi = all_se.max()
-        bins = np.logspace(np.log10(lo), np.log10(hi), 40)
-
-        ax.hist(noncliff_se, bins=bins, density=True, alpha=0.6, color="steelblue",
-                label=f"Non-cliff (med={np.median(noncliff_se):.3f})", edgecolor="white")
-        ax.hist(cliff_se, bins=bins, density=True, alpha=0.6, color="coral",
-                label=f"Cliff (med={np.median(cliff_se):.3f})", edgecolor="white")
-
-        ax.set_xscale("log")
-        ax.set_xlabel("Squared error")
-        ax.set_ylabel("Density")
-        ax.set_title(ep, fontsize=10, fontweight="bold")
-        ax.legend(fontsize=7)
-
-    for i in range(n_ep, len(axes)):
-        axes[i].set_visible(False)
-
-    fig.suptitle("Cliff vs non-cliff squared error distributions", fontsize=14, y=1.01)
-    fig.tight_layout()
-    fig.savefig(output_dir / "squared_error_distributions.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved squared_error_distributions.png")
-    plt.close("all")
-
-    # ── 6. Figure B: Cliff characterization ───────────────────────────
-    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
-
-    # Left: cliff molecule counts per endpoint
-    ax = axes[0]
-    ep_order = cliff_stats_df.sort_values("pct_cliff", ascending=False)["endpoint"]
-    x = np.arange(len(ep_order))
-    pcts = [cliff_stats_df[cliff_stats_df["endpoint"] == ep]["pct_cliff"].values[0] for ep in ep_order]
-    ax.bar(x, pcts, color="coral", edgecolor="white", alpha=0.8)
-    ax.set_xticks(x)
-    ax.set_xticklabels(ep_order, rotation=45, ha="right", fontsize=8)
-    ax.set_ylabel("% cliff molecules")
-    ax.set_title(f"Activity cliff prevalence (sim>{sim_threshold})")
-
-    # Right: cliff pairs vs n_similar_pairs
-    ax = axes[1]
-    ax.bar(x, [cliff_stats_df[cliff_stats_df["endpoint"] == ep]["n_cliff_pairs"].values[0] for ep in ep_order],
-           color="coral", edgecolor="white", alpha=0.8, label="Cliff pairs")
-    ax.set_xticks(x)
-    ax.set_xticklabels(ep_order, rotation=45, ha="right", fontsize=8)
-    ax.set_ylabel("Number of cliff pairs")
-    ax.set_title("Cliff pair counts per endpoint")
-
-    fig.tight_layout()
-    fig.savefig(output_dir / "cliff_characterization.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved cliff_characterization.png")
-    plt.close("all")
-
-    # ── 7. Figure C: Per-metric bar charts ────────────────────────────
-    x = np.arange(len(active_endpoints))
-    width = 0.35
-
-    metric_plots = [
-        ("median_se", "Median squared error", "median_se"),
-        ("mae", "MAE", "mae"),
-        ("r2", "R²", "r2"),
-        ("spearman_r", "Spearman ρ", "spearman"),
-        ("kendall_tau", "Kendall τ", "kendall"),
-        ("rae", "RAE", "rae"),
-    ]
-
-    for col, ylabel, fname in metric_plots:
-        fig, ax = plt.subplots(figsize=(10, 5))
-
-        cliff_vals = []
-        noncliff_vals = []
-        for ep in active_endpoints:
-            cliff_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "cliff")]
-            noncliff_row = metrics_df[(metrics_df["endpoint"] == ep) & (metrics_df["set"] == "non-cliff")]
-            cliff_vals.append(cliff_row[col].values[0] if not cliff_row.empty else np.nan)
-            noncliff_vals.append(noncliff_row[col].values[0] if not noncliff_row.empty else np.nan)
-
-        ax.bar(x - width / 2, noncliff_vals, width, label="Non-cliff",
-               color="steelblue", edgecolor="white", alpha=0.8)
-        ax.bar(x + width / 2, cliff_vals, width, label="Cliff",
-               color="coral", edgecolor="white", alpha=0.8)
-
-        ax.set_xticks(x)
-        ax.set_xticklabels(active_endpoints, rotation=45, ha="right", fontsize=8)
-        ax.set_ylabel(ylabel)
-        ax.set_title(f"Cliff vs non-cliff {ylabel} by endpoint")
-        ax.legend()
-        if col in ("r2",):
-            ax.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
-        fig.tight_layout()
-        fig.savefig(output_dir / f"{fname}_by_endpoint.png", dpi=dpi, bbox_inches="tight")
-        logger.info(f"Saved {fname}_by_endpoint.png")
-        plt.close("all")
-
-    logger.info(f"All outputs saved to {output_dir}")
+    # ── 5. Figures ────────────────────────────────────────────────────
+    _generate_figures(errors_df, metrics_df, model_dir, dpi)
+    logger.info(f"All outputs saved to {model_dir}")
 
 
 if __name__ == "__main__":

--- a/notebooks/2.11-seal-scaffold-vs-random.py
+++ b/notebooks/2.11-seal-scaffold-vs-random.py
@@ -528,7 +528,8 @@ def main(
                     test_prot = [prot_smiles[i] for i in test_idx_arr]
                     y_pred = train_chemprop(train_prot, y_tr, test_prot,
                                            cache_dir=chemprop_cache,
-                                           cache_key=f"2.11_{ep}_{strategy}_fold{fold_id}")
+                                           cache_key=f"2.11_{ep}_{strategy}_fold{fold_id}",
+                                           checkpoint_dir=model_dir / "models")
 
                 # Competition metrics
                 mae = mean_absolute_error(y_te, y_pred)

--- a/notebooks/2.11-seal-scaffold-vs-random.py
+++ b/notebooks/2.11-seal-scaffold-vs-random.py
@@ -7,17 +7,25 @@ to cluster-based splitting (from 2.03) which produces genuine structural separat
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.11-seal-scaffold-vs-random.py
+    pixi run -e cheminformatics python notebooks/2.11-seal-scaffold-vs-random.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.11-seal-scaffold-vs-random.py --combined
 
-Outputs:
-    data/processed/2.11-seal-scaffold-vs-random/summary_metrics.csv
-    data/processed/2.11-seal-scaffold-vs-random/aggregated_metrics.csv
-    data/processed/2.11-seal-scaffold-vs-random/distance_stats.csv
-    data/processed/2.11-seal-scaffold-vs-random/ks_distance_tests.csv
-    data/processed/2.11-seal-scaffold-vs-random/scaffold_group_stats.csv
-    data/processed/2.11-seal-scaffold-vs-random/scaffold_group_sizes.png
-    data/processed/2.11-seal-scaffold-vs-random/metric_comparison.png
-    data/processed/2.11-seal-scaffold-vs-random/distance_distributions.png
-    data/processed/2.11-seal-scaffold-vs-random/strategy_summary.png
+Outputs (per model, under data/processed/2.11-seal-scaffold-vs-random/<model>/):
+    summary_metrics.csv
+    aggregated_metrics.csv
+    distance_stats.csv
+    ks_distance_tests.csv
+    scaffold_group_stats.csv
+    metric_*.png
+    metric_comparison.png
+    distance_distributions.png
+    strategy_summary.png
+
+Model-agnostic outputs (directly in data/processed/2.11-seal-scaffold-vs-random/):
+    scaffold_group_sizes.png
+
+Combined outputs (--combined):
+    data/processed/2.11-seal-scaffold-vs-random/combined_*.png
 """
 
 from pathlib import Path
@@ -37,9 +45,14 @@ from scipy.stats import kendalltau, ks_2samp, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -170,195 +183,44 @@ def make_random_folds(n_molecules: int, n_folds: int = 5, seed: int = 42) -> np.
     return rng.integers(0, n_folds, size=n_molecules)
 
 
-@app.command()
-def main(
-    output_dir: Path = typer.Option(
-        PROCESSED_DATA_DIR / "2.11-seal-scaffold-vs-random", help="Output directory"
-    ),
-    dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move old flat XGBoost outputs into xgboost/ subdirectory."""
+    flat_files = [
+        "summary_metrics.csv",
+        "aggregated_metrics.csv",
+        "distance_stats.csv",
+        "ks_distance_tests.csv",
+        "scaffold_group_stats.csv",
+        "metric_comparison.png",
+        "distance_distributions.png",
+        "strategy_summary.png",
+    ]
+    # Also migrate any metric_*.png files
+    for p in output_dir.glob("metric_*.png"):
+        flat_files.append(p.name)
+
+    xgboost_dir = output_dir / "xgboost"
+    migrated = []
+    for fname in flat_files:
+        src = output_dir / fname
+        dst = xgboost_dir / fname
+        if src.exists() and not dst.exists():
+            xgboost_dir.mkdir(parents=True, exist_ok=True)
+            src.rename(dst)
+            migrated.append(fname)
+    if migrated:
+        logger.info(f"Migrated {len(migrated)} existing files → xgboost/")
+
+
+def _save_figures(
+    summary_df: pd.DataFrame,
+    agg_df: pd.DataFrame,
+    dist_df: pd.DataFrame,
+    dist_stats_df: pd.DataFrame,
+    model_dir: Path,
+    dpi: int,
 ) -> None:
-    set_style()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # ── 1. Load data ──────────────────────────────────────────────────
-    logger.info("Loading canonical dataset")
-    df = pd.read_parquet(INTERIM_DATA_DIR / "expansion_tx.parquet")
-    logger.info(f"Loaded {len(df)} molecules")
-
-    logger.info("Loading precomputed distance matrix")
-    npz = np.load(INTERIM_DATA_DIR / "tanimoto_distance_matrix.npz", allow_pickle=True)
-    dist_square = squareform(npz["condensed"])
-    dist_mol_names = npz["molecule_names"]
-    name_to_dist_idx = {str(n): i for i, n in enumerate(dist_mol_names)}
-
-    logger.info("Loading cluster CV folds")
-    cluster_folds = pd.read_parquet(INTERIM_DATA_DIR / "cluster_cv_folds.parquet")
-    cluster_folds = cluster_folds[cluster_folds["repeat"] == 0]
-
-    # ── 2. Train and evaluate per strategy per endpoint ───────────────
-    metric_rows = []
-    distance_rows = []  # per-molecule test-to-train 1-NN distances
-
-    for ep in ENDPOINTS:
-        ph = ENDPOINT_PH[ep]
-        mask = df[ep].notna().values
-        ep_df = df[mask].copy()
-        n_mol = len(ep_df)
-
-        if n_mol < 50:
-            logger.warning(f"Skipping {ep}: only {n_mol} molecules")
-            continue
-
-        names = ep_df["Molecule Name"].values
-        smiles = ep_df["SMILES"].tolist()
-
-        # Sub-distance-matrix for this endpoint
-        idx_in_full = np.array([name_to_dist_idx[n] for n in names])
-        D_sub = dist_square[np.ix_(idx_in_full, idx_in_full)]
-
-        # Activity values
-        raw_values = ep_df[ep].values
-        if ep in LOG_TRANSFORM_ENDPOINTS:
-            y_all = clip_and_log_transform(raw_values)
-        else:
-            y_all = raw_values
-
-        # Compute features once per endpoint
-        prot_smiles = protonate_at_ph(smiles, ph)
-        ecfp = compute_ecfp4(prot_smiles)
-        desc = compute_rdkit_descriptors(prot_smiles)
-        variance = desc.var(axis=0)
-        desc = desc[:, variance > 0]
-        scaler = StandardScaler()
-        desc_scaled = scaler.fit_transform(desc)
-        X_all = np.hstack([ecfp, desc_scaled])
-
-        # Generate fold assignments for each strategy
-        fold_assignments = {}
-
-        # Scaffold split
-        fold_assignments["scaffold"] = make_scaffold_folds(smiles, n_folds=5)
-
-        # Random split
-        fold_assignments["random"] = make_random_folds(n_mol, n_folds=5, seed=42)
-
-        # Cluster split (from precomputed)
-        ep_cluster = cluster_folds[cluster_folds["endpoint"] == ep]
-        cluster_map = dict(zip(ep_cluster["Molecule Name"], ep_cluster["fold"]))
-        fold_assignments["cluster"] = np.array([cluster_map.get(n, -1) for n in names])
-
-        logger.info(f"  {ep} ({n_mol} molecules)")
-
-        for strategy in STRATEGY_ORDER:
-            fold_ids = fold_assignments[strategy]
-            unique_folds = sorted(set(fold_ids[fold_ids >= 0]))
-
-            for fold_id in unique_folds:
-                test_mask = fold_ids == fold_id
-                train_mask = (fold_ids >= 0) & ~test_mask
-
-                X_tr = X_all[train_mask]
-                y_tr = y_all[train_mask]
-                X_te = X_all[test_mask]
-                y_te = y_all[test_mask]
-
-                if len(y_te) < 10 or len(y_tr) < 10:
-                    continue
-
-                # Train and predict
-                cache_dir = INTERIM_DATA_DIR / "optuna_cache"
-                model, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_{strategy}_fold{fold_id}")
-                y_pred = model.predict(X_te)
-
-                # Competition metrics
-                mae = mean_absolute_error(y_te, y_pred)
-                r2 = r2_score(y_te, y_pred)
-                sp_r, _ = spearmanr(y_te, y_pred)
-                kt, _ = kendalltau(y_te, y_pred)
-                baseline_mad = np.mean(np.abs(y_te - np.mean(y_te)))
-                rae = mae / baseline_mad if baseline_mad > 0 else np.nan
-
-                metric_rows.append({
-                    "endpoint": ep,
-                    "strategy": strategy,
-                    "fold": fold_id,
-                    "n_train": int(train_mask.sum()),
-                    "n_test": int(test_mask.sum()),
-                    "mae": mae,
-                    "r2": r2,
-                    "spearman_r": sp_r,
-                    "kendall_tau": kt,
-                    "rae": rae,
-                })
-
-                # Test-to-train 1-NN distances
-                test_idx = np.where(test_mask)[0]
-                train_idx = np.where(train_mask)[0]
-                nn1_dists = D_sub[np.ix_(test_idx, train_idx)].min(axis=1)
-
-                for d in nn1_dists:
-                    distance_rows.append({
-                        "endpoint": ep,
-                        "strategy": strategy,
-                        "fold": fold_id,
-                        "nn1_distance": d,
-                    })
-
-            logger.info(
-                f"    {strategy}: {len(unique_folds)} folds, "
-                f"sizes={[int((fold_ids == f).sum()) for f in unique_folds]}"
-            )
-
-    # ── 3. Save per-fold metrics ──────────────────────────────────────
-    summary_df = pd.DataFrame(metric_rows)
-    summary_df.to_csv(output_dir / "summary_metrics.csv", index=False)
-    logger.info(f"Saved summary_metrics.csv ({len(summary_df)} rows)")
-
-    # ── 4. Aggregate metrics (mean ± std per endpoint per strategy) ───
-    agg_rows = []
-    for (ep, strategy), grp in summary_df.groupby(["endpoint", "strategy"]):
-        row = {"endpoint": ep, "strategy": strategy, "n_folds": len(grp)}
-        for col in ["mae", "r2", "spearman_r", "kendall_tau", "rae"]:
-            row[f"{col}_mean"] = grp[col].mean()
-            row[f"{col}_std"] = grp[col].std()
-        agg_rows.append(row)
-
-    agg_df = pd.DataFrame(agg_rows)
-    agg_df.to_csv(output_dir / "aggregated_metrics.csv", index=False)
-    logger.info(f"Saved aggregated_metrics.csv ({len(agg_df)} rows)")
-
-    # Log MA-RAE per strategy
-    for strategy in STRATEGY_ORDER:
-        strat_sub = summary_df[summary_df["strategy"] == strategy]
-        ma_rae = strat_sub.groupby("fold")["rae"].mean().mean()
-        logger.info(f"MA-RAE ({strategy}): {ma_rae:.3f}")
-
-    # ── 5. Distance statistics ────────────────────────────────────────
-    dist_df = pd.DataFrame(distance_rows)
-    dist_stats_rows = []
-    for strategy in STRATEGY_ORDER:
-        s_dists = dist_df[dist_df["strategy"] == strategy]["nn1_distance"].values
-        dist_stats_rows.append({
-            "strategy": strategy,
-            "mean": np.mean(s_dists),
-            "median": np.median(s_dists),
-            "std": np.std(s_dists),
-            "q25": np.percentile(s_dists, 25),
-            "q75": np.percentile(s_dists, 75),
-            "q90": np.percentile(s_dists, 90),
-            "n": len(s_dists),
-        })
-
-    dist_stats_df = pd.DataFrame(dist_stats_rows)
-    dist_stats_df.to_csv(output_dir / "distance_stats.csv", index=False)
-    logger.info("Saved distance_stats.csv")
-    for _, row in dist_stats_df.iterrows():
-        logger.info(
-            f"  {row['strategy']}: median 1-NN={row['median']:.3f}, "
-            f"mean={row['mean']:.3f}, q75={row['q75']:.3f}"
-        )
-
-    # ── 6. Figure A: Per-metric comparison (grouped bar charts) ───────
+    """Generate and save all per-model figures."""
     active_endpoints = sorted(agg_df["endpoint"].unique())
     n_ep = len(active_endpoints)
     x = np.arange(n_ep)
@@ -401,7 +263,7 @@ def main(
             ax.axhline(y=0, color="gray", linestyle="--", alpha=0.3)
 
         fig.tight_layout()
-        fig.savefig(output_dir / f"metric_{col}.png", dpi=dpi, bbox_inches="tight")
+        fig.savefig(model_dir / f"metric_{col}.png", dpi=dpi, bbox_inches="tight")
         logger.info(f"Saved metric_{col}.png")
         plt.close("all")
 
@@ -440,11 +302,11 @@ def main(
 
     fig.suptitle("Scaffold vs random vs cluster split — performance comparison", fontsize=14, y=1.01)
     fig.tight_layout()
-    fig.savefig(output_dir / "metric_comparison.png", dpi=dpi, bbox_inches="tight")
+    fig.savefig(model_dir / "metric_comparison.png", dpi=dpi, bbox_inches="tight")
     logger.info("Saved metric_comparison.png")
     plt.close("all")
 
-    # ── 7. Figure B: Distance distributions ───────────────────────────
+    # Distance distributions
     fig, ax = plt.subplots(figsize=(10, 6))
 
     for strategy in STRATEGY_ORDER:
@@ -457,17 +319,16 @@ def main(
     ax.set_title("Test-to-train structural distance distributions by split strategy")
     ax.legend(fontsize=9)
     fig.tight_layout()
-    fig.savefig(output_dir / "distance_distributions.png", dpi=dpi, bbox_inches="tight")
+    fig.savefig(model_dir / "distance_distributions.png", dpi=dpi, bbox_inches="tight")
     logger.info("Saved distance_distributions.png")
     plt.close("all")
 
-    # ── 8. Figure C: Strategy summary (MA-RAE bar chart) ──────────────
+    # Strategy summary (MA-RAE bar chart)
     fig, ax = plt.subplots(figsize=(6, 4))
 
     ma_raes = []
     for strategy in STRATEGY_ORDER:
         strat_sub = summary_df[summary_df["strategy"] == strategy]
-        # MA-RAE: mean RAE across endpoints, then mean across folds
         ma_rae = strat_sub.groupby("fold")["rae"].mean().mean()
         ma_raes.append(ma_rae)
 
@@ -483,11 +344,284 @@ def main(
     ax.set_title("Mean-across-endpoints RAE by split strategy")
     ax.axhline(y=1, color="gray", linestyle="--", alpha=0.3)
     fig.tight_layout()
-    fig.savefig(output_dir / "strategy_summary.png", dpi=dpi, bbox_inches="tight")
+    fig.savefig(model_dir / "strategy_summary.png", dpi=dpi, bbox_inches="tight")
     logger.info("Saved strategy_summary.png")
     plt.close("all")
 
-    # ── 9. KS tests on distance distributions ──────────────────────
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Load both models' aggregated_metrics.csv and produce combined comparison figures."""
+    xgb_path = output_dir / "xgboost" / "aggregated_metrics.csv"
+    chemprop_path = output_dir / "chemprop" / "aggregated_metrics.csv"
+
+    missing = [p for p in [xgb_path, chemprop_path] if not p.exists()]
+    if missing:
+        logger.error(f"Cannot generate combined figures — missing: {[str(p) for p in missing]}")
+        return
+
+    xgb_df = pd.read_csv(xgb_path)
+    chemprop_df = pd.read_csv(chemprop_path)
+
+    metrics = [
+        ("mae_mean", "MAE"),
+        ("r2_mean", "R²"),
+        ("spearman_r_mean", "Spearman ρ"),
+        ("rae_mean", "RAE"),
+    ]
+
+    for strategy in STRATEGY_ORDER:
+        xgb_strat = xgb_df[xgb_df["strategy"] == strategy].copy()
+        chemprop_strat = chemprop_df[chemprop_df["strategy"] == strategy].copy()
+
+        if xgb_strat.empty and chemprop_strat.empty:
+            continue
+
+        for metric_col, ylabel in metrics:
+            out_path = output_dir / f"combined_{strategy}_{metric_col.replace('_mean', '')}.png"
+            plot_model_comparison_bars(
+                data_by_model={"xgboost": xgb_strat, "chemprop": chemprop_strat},
+                endpoint_col="endpoint",
+                metric_col=metric_col,
+                ylabel=ylabel,
+                title=f"{ylabel} — {strategy} split: XGBoost vs Chemprop",
+                output_path=out_path,
+                dpi=dpi,
+            )
+            logger.info(f"Saved {out_path.name}")
+
+    logger.info(f"Combined figures saved to {output_dir}")
+
+
+@app.command()
+def main(
+    output_dir: Path = typer.Option(
+        PROCESSED_DATA_DIR / "2.11-seal-scaffold-vs-random", help="Output directory"
+    ),
+    dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+) -> None:
+    set_style()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if combined:
+        _generate_combined_figures(output_dir, dpi)
+        return
+
+    _migrate_flat_outputs(output_dir)
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── 1. Load data ──────────────────────────────────────────────────
+    logger.info("Loading canonical dataset")
+    df = pd.read_parquet(INTERIM_DATA_DIR / "expansion_tx.parquet")
+    logger.info(f"Loaded {len(df)} molecules")
+
+    logger.info("Loading precomputed distance matrix")
+    npz = np.load(INTERIM_DATA_DIR / "tanimoto_distance_matrix.npz", allow_pickle=True)
+    dist_square = squareform(npz["condensed"])
+    dist_mol_names = npz["molecule_names"]
+    name_to_dist_idx = {str(n): i for i, n in enumerate(dist_mol_names)}
+
+    logger.info("Loading cluster CV folds")
+    cluster_folds = pd.read_parquet(INTERIM_DATA_DIR / "cluster_cv_folds.parquet")
+    cluster_folds = cluster_folds[cluster_folds["repeat"] == 0]
+
+    # Skip training if key outputs already exist
+    if (model_dir / "summary_metrics.csv").exists():
+        logger.info(f"Existing {model} outputs found — regenerating figures only")
+        summary_df = pd.read_csv(model_dir / "summary_metrics.csv")
+        agg_df = pd.read_csv(model_dir / "aggregated_metrics.csv")
+        dist_df_loaded = pd.read_csv(model_dir / "distance_stats.csv")
+        # Reconstruct distance_rows from summary if dist_df_loaded only has stats
+        # (distance_distributions.png needs per-molecule distances — skip regeneration if unavailable)
+        # We'll still regenerate the metric and strategy figures from agg/summary
+        _save_figures(summary_df, agg_df, pd.DataFrame(columns=["strategy", "nn1_distance"]),
+                      dist_df_loaded, model_dir, dpi)
+        logger.info(f"Figures regenerated in {model_dir}")
+        return
+
+    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+
+    # ── 2. Train and evaluate per strategy per endpoint ───────────────
+    metric_rows = []
+    distance_rows = []  # per-molecule test-to-train 1-NN distances
+
+    for ep in ENDPOINTS:
+        ph = ENDPOINT_PH[ep]
+        mask = df[ep].notna().values
+        ep_df = df[mask].copy()
+        n_mol = len(ep_df)
+
+        if n_mol < 50:
+            logger.warning(f"Skipping {ep}: only {n_mol} molecules")
+            continue
+
+        names = ep_df["Molecule Name"].values
+        smiles = ep_df["SMILES"].tolist()
+
+        # Sub-distance-matrix for this endpoint
+        idx_in_full = np.array([name_to_dist_idx[n] for n in names])
+        D_sub = dist_square[np.ix_(idx_in_full, idx_in_full)]
+
+        # Activity values
+        raw_values = ep_df[ep].values
+        if ep in LOG_TRANSFORM_ENDPOINTS:
+            y_all = clip_and_log_transform(raw_values)
+        else:
+            y_all = raw_values
+
+        # Always: protonate (needed for both XGBoost and Chemprop)
+        prot_smiles = protonate_at_ph(smiles, ph)
+
+        # XGBoost only: feature computation
+        if model == "xgboost":
+            ecfp = compute_ecfp4(prot_smiles)
+            desc = compute_rdkit_descriptors(prot_smiles)
+            variance = desc.var(axis=0)
+            desc = desc[:, variance > 0]
+            scaler = StandardScaler()
+            desc_scaled = scaler.fit_transform(desc)
+            X_all = np.hstack([ecfp, desc_scaled])
+
+        # Generate fold assignments for each strategy
+        fold_assignments = {}
+
+        # Scaffold split
+        fold_assignments["scaffold"] = make_scaffold_folds(smiles, n_folds=5)
+
+        # Random split
+        fold_assignments["random"] = make_random_folds(n_mol, n_folds=5, seed=42)
+
+        # Cluster split (from precomputed)
+        ep_cluster = cluster_folds[cluster_folds["endpoint"] == ep]
+        cluster_map = dict(zip(ep_cluster["Molecule Name"], ep_cluster["fold"]))
+        fold_assignments["cluster"] = np.array([cluster_map.get(n, -1) for n in names])
+
+        logger.info(f"  {ep} ({n_mol} molecules)")
+
+        for strategy in STRATEGY_ORDER:
+            fold_ids = fold_assignments[strategy]
+            unique_folds = sorted(set(fold_ids[fold_ids >= 0]))
+
+            for fold_id in unique_folds:
+                test_mask = fold_ids == fold_id
+                train_mask = (fold_ids >= 0) & ~test_mask
+
+                y_tr = y_all[train_mask]
+                y_te = y_all[test_mask]
+
+                if len(y_te) < 10 or len(y_tr) < 10:
+                    continue
+
+                # Train and predict
+                if model == "xgboost":
+                    X_tr = X_all[train_mask]
+                    X_te = X_all[test_mask]
+                    cache_dir = INTERIM_DATA_DIR / "optuna_cache"
+                    model_obj, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_{strategy}_fold{fold_id}")
+                    y_pred = model_obj.predict(X_te)
+                else:
+                    train_idx = np.where(train_mask)[0]
+                    test_idx_arr = np.where(test_mask)[0]
+                    train_prot = [prot_smiles[i] for i in train_idx]
+                    test_prot = [prot_smiles[i] for i in test_idx_arr]
+                    y_pred = train_chemprop(train_prot, y_tr, test_prot,
+                                           cache_dir=chemprop_cache,
+                                           cache_key=f"2.11_{ep}_{strategy}_fold{fold_id}")
+
+                # Competition metrics
+                mae = mean_absolute_error(y_te, y_pred)
+                r2 = r2_score(y_te, y_pred)
+                sp_r, _ = spearmanr(y_te, y_pred)
+                kt, _ = kendalltau(y_te, y_pred)
+                baseline_mad = np.mean(np.abs(y_te - np.mean(y_te)))
+                rae = mae / baseline_mad if baseline_mad > 0 else np.nan
+
+                metric_rows.append({
+                    "endpoint": ep,
+                    "strategy": strategy,
+                    "fold": fold_id,
+                    "n_train": int(train_mask.sum()),
+                    "n_test": int(test_mask.sum()),
+                    "mae": mae,
+                    "r2": r2,
+                    "spearman_r": sp_r,
+                    "kendall_tau": kt,
+                    "rae": rae,
+                })
+
+                # Test-to-train 1-NN distances
+                test_idx = np.where(test_mask)[0]
+                train_idx = np.where(train_mask)[0]
+                nn1_dists = D_sub[np.ix_(test_idx, train_idx)].min(axis=1)
+
+                for d in nn1_dists:
+                    distance_rows.append({
+                        "endpoint": ep,
+                        "strategy": strategy,
+                        "fold": fold_id,
+                        "nn1_distance": d,
+                    })
+
+            logger.info(
+                f"    {strategy}: {len(unique_folds)} folds, "
+                f"sizes={[int((fold_ids == f).sum()) for f in unique_folds]}"
+            )
+
+    # ── 3. Save per-fold metrics ──────────────────────────────────────
+    summary_df = pd.DataFrame(metric_rows)
+    summary_df.to_csv(model_dir / "summary_metrics.csv", index=False)
+    logger.info(f"Saved summary_metrics.csv ({len(summary_df)} rows)")
+
+    # ── 4. Aggregate metrics (mean ± std per endpoint per strategy) ───
+    agg_rows = []
+    for (ep, strategy), grp in summary_df.groupby(["endpoint", "strategy"]):
+        row = {"endpoint": ep, "strategy": strategy, "n_folds": len(grp)}
+        for col in ["mae", "r2", "spearman_r", "kendall_tau", "rae"]:
+            row[f"{col}_mean"] = grp[col].mean()
+            row[f"{col}_std"] = grp[col].std()
+        agg_rows.append(row)
+
+    agg_df = pd.DataFrame(agg_rows)
+    agg_df.to_csv(model_dir / "aggregated_metrics.csv", index=False)
+    logger.info(f"Saved aggregated_metrics.csv ({len(agg_df)} rows)")
+
+    # Log MA-RAE per strategy
+    for strategy in STRATEGY_ORDER:
+        strat_sub = summary_df[summary_df["strategy"] == strategy]
+        ma_rae = strat_sub.groupby("fold")["rae"].mean().mean()
+        logger.info(f"MA-RAE ({strategy}): {ma_rae:.3f}")
+
+    # ── 5. Distance statistics ────────────────────────────────────────
+    dist_df = pd.DataFrame(distance_rows)
+    dist_stats_rows = []
+    for strategy in STRATEGY_ORDER:
+        s_dists = dist_df[dist_df["strategy"] == strategy]["nn1_distance"].values
+        dist_stats_rows.append({
+            "strategy": strategy,
+            "mean": np.mean(s_dists),
+            "median": np.median(s_dists),
+            "std": np.std(s_dists),
+            "q25": np.percentile(s_dists, 25),
+            "q75": np.percentile(s_dists, 75),
+            "q90": np.percentile(s_dists, 90),
+            "n": len(s_dists),
+        })
+
+    dist_stats_df = pd.DataFrame(dist_stats_rows)
+    dist_stats_df.to_csv(model_dir / "distance_stats.csv", index=False)
+    logger.info("Saved distance_stats.csv")
+    for _, row in dist_stats_df.iterrows():
+        logger.info(
+            f"  {row['strategy']}: median 1-NN={row['median']:.3f}, "
+            f"mean={row['mean']:.3f}, q75={row['q75']:.3f}"
+        )
+
+    # ── 6. Figures ────────────────────────────────────────────────────
+    _save_figures(summary_df, agg_df, dist_df, dist_stats_df, model_dir, dpi)
+
+    # ── 7. KS tests on distance distributions ──────────────────────
     logger.info("Computing KS tests on 1-NN distance distributions")
 
     comparisons = [
@@ -520,10 +654,14 @@ def main(
         )
 
     ks_df = pd.DataFrame(ks_rows)
-    ks_df.to_csv(output_dir / "ks_distance_tests.csv", index=False)
+    ks_df.to_csv(model_dir / "ks_distance_tests.csv", index=False)
     logger.info("Saved ks_distance_tests.csv")
 
-    # ── 10. Scaffold group size statistics ─────────────────────────
+    # ── 8. Scaffold group size statistics ─────────────────────────
+    # Model-agnostic: save directly in output_dir
+    scaffold_group_sizes_path = output_dir / "scaffold_group_sizes.png"
+    scaffold_group_stats_path = model_dir / "scaffold_group_stats.csv"
+
     logger.info("Computing scaffold group size statistics")
 
     all_smiles = df["SMILES"].tolist()
@@ -547,33 +685,36 @@ def main(
         "max_group_size": int(np.max(group_sizes)),
     }
     stats_df = pd.DataFrame([stats])
-    stats_df.to_csv(output_dir / "scaffold_group_stats.csv", index=False)
+    stats_df.to_csv(scaffold_group_stats_path, index=False)
     logger.info(
         f"  {n_unique} unique scaffolds, {n_singletons} singletons "
         f"({stats['pct_singletons']:.1f}%), median size {stats['median_group_size']}"
     )
 
-    # Histogram of scaffold group sizes
-    fig, ax = plt.subplots(figsize=(8, 4))
-    max_display = 20
-    bins = np.arange(1, max_display + 2) - 0.5
-    clipped = np.clip(group_sizes, 1, max_display)
-    ax.hist(clipped, bins=bins, color="coral", edgecolor="white", alpha=0.8)
-    tick_labels = [str(i) for i in range(1, max_display)] + [f"{max_display}+"]
-    ax.set_xticks(range(1, max_display + 1))
-    ax.set_xticklabels(tick_labels, fontsize=8)
-    ax.set_xlabel("Scaffold group size")
-    ax.set_ylabel("Number of scaffolds")
-    ax.set_title(
-        f"Murcko scaffold group size distribution "
-        f"({n_singletons}/{n_unique} = {stats['pct_singletons']:.0f}% singletons)"
-    )
-    fig.tight_layout()
-    fig.savefig(output_dir / "scaffold_group_sizes.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved scaffold_group_sizes.png")
-    plt.close("all")
+    # Histogram of scaffold group sizes (model-agnostic, saved to output_dir)
+    if not scaffold_group_sizes_path.exists():
+        fig, ax = plt.subplots(figsize=(8, 4))
+        max_display = 20
+        bins = np.arange(1, max_display + 2) - 0.5
+        clipped = np.clip(group_sizes, 1, max_display)
+        ax.hist(clipped, bins=bins, color="coral", edgecolor="white", alpha=0.8)
+        tick_labels = [str(i) for i in range(1, max_display)] + [f"{max_display}+"]
+        ax.set_xticks(range(1, max_display + 1))
+        ax.set_xticklabels(tick_labels, fontsize=8)
+        ax.set_xlabel("Scaffold group size")
+        ax.set_ylabel("Number of scaffolds")
+        ax.set_title(
+            f"Murcko scaffold group size distribution "
+            f"({n_singletons}/{n_unique} = {stats['pct_singletons']:.0f}% singletons)"
+        )
+        fig.tight_layout()
+        fig.savefig(scaffold_group_sizes_path, dpi=dpi, bbox_inches="tight")
+        logger.info("Saved scaffold_group_sizes.png")
+        plt.close("all")
+    else:
+        logger.info("scaffold_group_sizes.png already exists — skipping")
 
-    logger.info(f"All outputs saved to {output_dir}")
+    logger.info(f"All outputs saved to {model_dir}")
 
 
 if __name__ == "__main__":

--- a/notebooks/2.12-seal-split-variance.py
+++ b/notebooks/2.12-seal-split-variance.py
@@ -517,7 +517,8 @@ def main(
                     test_prot = [prot_smiles[i] for i in np.where(test_mask)[0]]
                     y_pred = train_chemprop(train_prot, y_tr, test_prot,
                                            cache_dir=chemprop_cache,
-                                           cache_key=f"2.12_{ep}_random_r{repeat}_fold{fold_id}")
+                                           cache_key=f"2.12_{ep}_random_r{repeat}_fold{fold_id}",
+                                           checkpoint_dir=model_dir / "models")
 
                 mae = mean_absolute_error(y_te, y_pred)
                 r2 = r2_score(y_te, y_pred)
@@ -570,7 +571,8 @@ def main(
                     test_prot = [prot_smiles[i] for i in np.where(test_mask)[0]]
                     y_pred = train_chemprop(train_prot, y_tr, test_prot,
                                            cache_dir=chemprop_cache,
-                                           cache_key=f"2.12_{ep}_cluster_r{repeat}_fold{fold_id}")
+                                           cache_key=f"2.12_{ep}_cluster_r{repeat}_fold{fold_id}",
+                                           checkpoint_dir=model_dir / "models")
 
                 mae = mean_absolute_error(y_te, y_pred)
                 r2 = r2_score(y_te, y_pred)

--- a/notebooks/2.12-seal-split-variance.py
+++ b/notebooks/2.12-seal-split-variance.py
@@ -8,17 +8,22 @@ intervals rather than single point estimates.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.12-seal-split-variance.py
+    pixi run -e cheminformatics python notebooks/2.12-seal-split-variance.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.12-seal-split-variance.py --combined
 
-Outputs:
-    data/processed/2.12-seal-split-variance/summary_metrics.csv
-    data/processed/2.12-seal-split-variance/repeat_aggregates.csv
-    data/processed/2.12-seal-split-variance/variance_summary.csv
-    data/processed/2.12-seal-split-variance/mannwhitney_rae_tests.csv
-    data/processed/2.12-seal-split-variance/rae_distributions.png
-    data/processed/2.12-seal-split-variance/r2_distributions.png
-    data/processed/2.12-seal-split-variance/ma_rae_distribution.png
-    data/processed/2.12-seal-split-variance/variance_heatmap.png
-    data/processed/2.12-seal-split-variance/single_split_danger.png
+Outputs (per model, under data/processed/2.12-seal-split-variance/<model>/):
+    summary_metrics.csv
+    repeat_aggregates.csv
+    variance_summary.csv
+    mannwhitney_rae_tests.csv
+    rae_distributions.png
+    r2_distributions.png
+    ma_rae_distribution.png
+    variance_heatmap.png
+    single_split_danger.png
+
+Combined outputs (--combined):
+    data/processed/2.12-seal-split-variance/combined_*.png
 """
 
 from pathlib import Path
@@ -37,9 +42,14 @@ from scipy.stats import kendalltau, mannwhitneyu, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -122,199 +132,42 @@ def make_random_folds(n_molecules: int, n_folds: int = 5, seed: int = 0) -> np.n
     return rng.integers(0, n_folds, size=n_molecules)
 
 
-@app.command()
-def main(
-    output_dir: Path = typer.Option(
-        PROCESSED_DATA_DIR / "2.12-seal-split-variance", help="Output directory"
-    ),
-    dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
-    n_random_repeats: int = typer.Option(5, help="Number of random split repeats"),
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move old flat XGBoost outputs into xgboost/ subdirectory."""
+    flat_files = [
+        "summary_metrics.csv",
+        "repeat_aggregates.csv",
+        "variance_summary.csv",
+        "mannwhitney_rae_tests.csv",
+        "rae_distributions.png",
+        "r2_distributions.png",
+        "ma_rae_distribution.png",
+        "variance_heatmap.png",
+        "single_split_danger.png",
+    ]
+    xgboost_dir = output_dir / "xgboost"
+    migrated = []
+    for fname in flat_files:
+        src = output_dir / fname
+        dst = xgboost_dir / fname
+        if src.exists() and not dst.exists():
+            xgboost_dir.mkdir(parents=True, exist_ok=True)
+            src.rename(dst)
+            migrated.append(fname)
+    if migrated:
+        logger.info(f"Migrated {len(migrated)} existing files → xgboost/")
+
+
+def _save_figures(
+    summary_df: pd.DataFrame,
+    repeat_agg: pd.DataFrame,
+    var_df: pd.DataFrame,
+    model_dir: Path,
+    dpi: int,
+    n_random_repeats: int,
+    n_cluster_repeats: int,
 ) -> None:
-    set_style()
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    # ── 1. Load data ──────────────────────────────────────────────────
-    logger.info("Loading canonical dataset")
-    df = pd.read_parquet(INTERIM_DATA_DIR / "expansion_tx.parquet")
-    logger.info(f"Loaded {len(df)} molecules")
-
-    logger.info("Loading cluster CV folds (all 5 repeats)")
-    cluster_folds = pd.read_parquet(INTERIM_DATA_DIR / "cluster_cv_folds.parquet")
-    n_cluster_repeats = cluster_folds["repeat"].nunique()
-    logger.info(f"Cluster folds: {len(cluster_folds)} rows, {n_cluster_repeats} repeats")
-
-    # ── 2. Train and evaluate per strategy per repeat per endpoint ────
-    metric_rows = []
-
-    for ep in ENDPOINTS:
-        ph = ENDPOINT_PH[ep]
-        mask = df[ep].notna().values
-        ep_df = df[mask].copy()
-        n_mol = len(ep_df)
-
-        if n_mol < 50:
-            logger.warning(f"Skipping {ep}: only {n_mol} molecules")
-            continue
-
-        names = ep_df["Molecule Name"].values
-        smiles = ep_df["SMILES"].tolist()
-
-        # Activity values
-        raw_values = ep_df[ep].values
-        if ep in LOG_TRANSFORM_ENDPOINTS:
-            y_all = clip_and_log_transform(raw_values)
-        else:
-            y_all = raw_values
-
-        # Compute features once per endpoint (shared across all repeats)
-        prot_smiles = protonate_at_ph(smiles, ph)
-        ecfp = compute_ecfp4(prot_smiles)
-        desc = compute_rdkit_descriptors(prot_smiles)
-        variance = desc.var(axis=0)
-        desc = desc[:, variance > 0]
-        scaler = StandardScaler()
-        desc_scaled = scaler.fit_transform(desc)
-        X_all = np.hstack([ecfp, desc_scaled])
-
-        logger.info(f"  {ep} ({n_mol} molecules, {X_all.shape[1]} features)")
-
-        # ── Random repeats ────────────────────────────────────────────
-        for repeat in range(n_random_repeats):
-            fold_ids = make_random_folds(n_mol, n_folds=5, seed=repeat)
-            unique_folds = sorted(set(fold_ids))
-
-            for fold_id in unique_folds:
-                test_mask = fold_ids == fold_id
-                train_mask = ~test_mask
-
-                X_tr, y_tr = X_all[train_mask], y_all[train_mask]
-                X_te, y_te = X_all[test_mask], y_all[test_mask]
-
-                if len(y_te) < 10 or len(y_tr) < 10:
-                    continue
-
-                cache_dir = INTERIM_DATA_DIR / "optuna_cache"
-                model, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_random_r{repeat}_fold{fold_id}")
-                y_pred = model.predict(X_te)
-
-                mae = mean_absolute_error(y_te, y_pred)
-                r2 = r2_score(y_te, y_pred)
-                sp_r, _ = spearmanr(y_te, y_pred)
-                kt, _ = kendalltau(y_te, y_pred)
-                baseline_mad = np.mean(np.abs(y_te - np.mean(y_te)))
-                rae = mae / baseline_mad if baseline_mad > 0 else np.nan
-
-                metric_rows.append({
-                    "endpoint": ep,
-                    "strategy": "random",
-                    "repeat": repeat,
-                    "fold": fold_id,
-                    "n_train": int(train_mask.sum()),
-                    "n_test": int(test_mask.sum()),
-                    "mae": mae,
-                    "r2": r2,
-                    "spearman_r": sp_r,
-                    "kendall_tau": kt,
-                    "rae": rae,
-                })
-
-        logger.info(f"    random: {n_random_repeats} repeats done")
-
-        # ── Cluster repeats ───────────────────────────────────────────
-        ep_cluster = cluster_folds[cluster_folds["endpoint"] == ep]
-
-        for repeat in range(n_cluster_repeats):
-            rep_folds = ep_cluster[ep_cluster["repeat"] == repeat]
-            fold_map = dict(zip(rep_folds["Molecule Name"], rep_folds["fold"]))
-            fold_ids = np.array([fold_map.get(n, -1) for n in names])
-            unique_folds = sorted(set(fold_ids[fold_ids >= 0]))
-
-            for fold_id in unique_folds:
-                test_mask = fold_ids == fold_id
-                train_mask = (fold_ids >= 0) & ~test_mask
-
-                X_tr, y_tr = X_all[train_mask], y_all[train_mask]
-                X_te, y_te = X_all[test_mask], y_all[test_mask]
-
-                if len(y_te) < 10 or len(y_tr) < 10:
-                    continue
-
-                model, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_cluster_r{repeat}_fold{fold_id}")
-                y_pred = model.predict(X_te)
-
-                mae = mean_absolute_error(y_te, y_pred)
-                r2 = r2_score(y_te, y_pred)
-                sp_r, _ = spearmanr(y_te, y_pred)
-                kt, _ = kendalltau(y_te, y_pred)
-                baseline_mad = np.mean(np.abs(y_te - np.mean(y_te)))
-                rae = mae / baseline_mad if baseline_mad > 0 else np.nan
-
-                metric_rows.append({
-                    "endpoint": ep,
-                    "strategy": "cluster",
-                    "repeat": repeat,
-                    "fold": fold_id,
-                    "n_train": int(train_mask.sum()),
-                    "n_test": int(test_mask.sum()),
-                    "mae": mae,
-                    "r2": r2,
-                    "spearman_r": sp_r,
-                    "kendall_tau": kt,
-                    "rae": rae,
-                })
-
-        logger.info(f"    cluster: {n_cluster_repeats} repeats done")
-
-    # ── 3. Save per-fold metrics ──────────────────────────────────────
-    summary_df = pd.DataFrame(metric_rows)
-    summary_df.to_csv(output_dir / "summary_metrics.csv", index=False)
-    logger.info(f"Saved summary_metrics.csv ({len(summary_df)} rows)")
-
-    # ── 4. Per-repeat aggregates (mean across folds) ──────────────────
-    repeat_agg = (
-        summary_df.groupby(["endpoint", "strategy", "repeat"])
-        .agg(
-            mae_mean=("mae", "mean"),
-            r2_mean=("r2", "mean"),
-            spearman_r_mean=("spearman_r", "mean"),
-            kendall_tau_mean=("kendall_tau", "mean"),
-            rae_mean=("rae", "mean"),
-        )
-        .reset_index()
-    )
-    repeat_agg.to_csv(output_dir / "repeat_aggregates.csv", index=False)
-    logger.info(f"Saved repeat_aggregates.csv ({len(repeat_agg)} rows)")
-
-    # ── 5. Variance summary per endpoint per strategy ─────────────────
-    var_rows = []
-    for (ep, strategy), grp in repeat_agg.groupby(["endpoint", "strategy"]):
-        row = {"endpoint": ep, "strategy": strategy, "n_repeats": len(grp)}
-        for col in ["mae_mean", "r2_mean", "spearman_r_mean", "kendall_tau_mean", "rae_mean"]:
-            vals = grp[col].values
-            metric_name = col.replace("_mean", "")
-            row[f"{metric_name}_mean"] = np.mean(vals)
-            row[f"{metric_name}_std"] = np.std(vals)
-            row[f"{metric_name}_min"] = np.min(vals)
-            row[f"{metric_name}_max"] = np.max(vals)
-            row[f"{metric_name}_range"] = np.max(vals) - np.min(vals)
-            row[f"{metric_name}_cv"] = np.std(vals) / abs(np.mean(vals)) if np.mean(vals) != 0 else np.nan
-            # 95% CI (using t-distribution approximation for small n)
-            row[f"{metric_name}_ci95"] = 1.96 * np.std(vals) / np.sqrt(len(vals))
-        var_rows.append(row)
-
-    var_df = pd.DataFrame(var_rows)
-    var_df.to_csv(output_dir / "variance_summary.csv", index=False)
-    logger.info("Saved variance_summary.csv")
-
-    for _, row in var_df.iterrows():
-        logger.info(
-            f"  {row['endpoint']} ({row['strategy']}, n={row['n_repeats']}): "
-            f"RAE={row['rae_mean']:.3f}±{row['rae_std']:.3f} "
-            f"[{row['rae_min']:.3f}–{row['rae_max']:.3f}], "
-            f"R²={row['r2_mean']:.3f}±{row['r2_std']:.3f}"
-        )
-
-    # ── 6. Figure A: Per-endpoint RAE distributions ───────────────────
+    """Generate and save all per-model figures."""
     active_endpoints = sorted(repeat_agg["endpoint"].unique())
     n_ep = len(active_endpoints)
     nrows = (n_ep + 2) // 3
@@ -380,17 +233,16 @@ def main(
             fontsize=14, y=1.01,
         )
         fig.tight_layout()
-        fig.savefig(output_dir / f"{fig_name}.png", dpi=dpi, bbox_inches="tight")
+        fig.savefig(model_dir / f"{fig_name}.png", dpi=dpi, bbox_inches="tight")
         logger.info(f"Saved {fig_name}.png")
         plt.close("all")
 
-    # ── 7. Figure B: MA-RAE distribution across repeats ───────────────
+    # MA-RAE distribution across repeats
     fig, ax = plt.subplots(figsize=(8, 5))
 
     ma_rae_data = {}
     for strategy in STRATEGY_ORDER:
         strat_agg = repeat_agg[repeat_agg["strategy"] == strategy]
-        # MA-RAE per repeat: mean RAE across endpoints for each repeat
         ma_raes = strat_agg.groupby("repeat")["rae_mean"].mean().values
         ma_rae_data[strategy] = ma_raes
 
@@ -426,11 +278,11 @@ def main(
     ax.set_title("MA-RAE distribution across repeated splits", fontsize=13)
     ax.axhline(y=1, color="gray", linestyle="--", alpha=0.3)
     fig.tight_layout()
-    fig.savefig(output_dir / "ma_rae_distribution.png", dpi=dpi, bbox_inches="tight")
+    fig.savefig(model_dir / "ma_rae_distribution.png", dpi=dpi, bbox_inches="tight")
     logger.info("Saved ma_rae_distribution.png")
     plt.close("all")
 
-    # ── 8. Figure C: Variance summary heatmap ─────────────────────────
+    # Variance summary heatmap
     metric_cols = ["mae", "r2", "spearman_r", "rae"]
     metric_labels = ["MAE", "R²", "Spearman ρ", "RAE"]
 
@@ -456,12 +308,11 @@ def main(
 
     fig.suptitle("Metric variance (coefficient of variation) across repeated splits", fontsize=13, y=1.02)
     fig.tight_layout()
-    fig.savefig(output_dir / "variance_heatmap.png", dpi=dpi, bbox_inches="tight")
+    fig.savefig(model_dir / "variance_heatmap.png", dpi=dpi, bbox_inches="tight")
     logger.info("Saved variance_heatmap.png")
     plt.close("all")
 
-    # ── 9. Figure D: Single-split danger illustration ─────────────────
-    # Find endpoint with highest RAE range for cluster strategy
+    # Single-split danger illustration
     cluster_var = var_df[var_df["strategy"] == "cluster"]
     if not cluster_var.empty:
         worst_ep = cluster_var.loc[cluster_var["rae_range"].idxmax(), "endpoint"]
@@ -484,7 +335,6 @@ def main(
             color=STRATEGY_COLORS[strategy], edgecolor="white", alpha=0.8,
         )
 
-        # Highlight best and worst
         best_idx = np.argmin(vals)
         worst_idx = np.argmax(vals)
         ax.bar(best_idx, vals[best_idx], color="green", edgecolor="white", alpha=0.9)
@@ -512,11 +362,293 @@ def main(
         fontsize=13, y=1.02,
     )
     fig.tight_layout()
-    fig.savefig(output_dir / "single_split_danger.png", dpi=dpi, bbox_inches="tight")
+    fig.savefig(model_dir / "single_split_danger.png", dpi=dpi, bbox_inches="tight")
     logger.info("Saved single_split_danger.png")
     plt.close("all")
 
-    # ── 10. Mann-Whitney U tests: cluster vs random RAE ─────────────
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Load both models' variance_summary.csv and produce combined comparison figures."""
+    xgb_path = output_dir / "xgboost" / "variance_summary.csv"
+    chemprop_path = output_dir / "chemprop" / "variance_summary.csv"
+
+    missing = [p for p in [xgb_path, chemprop_path] if not p.exists()]
+    if missing:
+        logger.error(f"Cannot generate combined figures — missing: {[str(p) for p in missing]}")
+        return
+
+    xgb_df = pd.read_csv(xgb_path)
+    chemprop_df = pd.read_csv(chemprop_path)
+
+    metrics = [
+        ("mae_mean", "MAE"),
+        ("r2_mean", "R²"),
+        ("spearman_r_mean", "Spearman ρ"),
+        ("rae_mean", "RAE"),
+    ]
+
+    for strategy in STRATEGY_ORDER:
+        xgb_strat = xgb_df[xgb_df["strategy"] == strategy].copy()
+        chemprop_strat = chemprop_df[chemprop_df["strategy"] == strategy].copy()
+
+        if xgb_strat.empty and chemprop_strat.empty:
+            continue
+
+        for metric_col, ylabel in metrics:
+            out_path = output_dir / f"combined_{strategy}_{metric_col.replace('_mean', '')}.png"
+            plot_model_comparison_bars(
+                data_by_model={"xgboost": xgb_strat, "chemprop": chemprop_strat},
+                endpoint_col="endpoint",
+                metric_col=metric_col,
+                ylabel=ylabel,
+                title=f"{ylabel} variance ({strategy} split): XGBoost vs Chemprop",
+                output_path=out_path,
+                dpi=dpi,
+            )
+            logger.info(f"Saved {out_path.name}")
+
+    logger.info(f"Combined figures saved to {output_dir}")
+
+
+@app.command()
+def main(
+    output_dir: Path = typer.Option(
+        PROCESSED_DATA_DIR / "2.12-seal-split-variance", help="Output directory"
+    ),
+    dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
+    n_random_repeats: int = typer.Option(5, help="Number of random split repeats"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+) -> None:
+    set_style()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if combined:
+        _generate_combined_figures(output_dir, dpi)
+        return
+
+    _migrate_flat_outputs(output_dir)
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── 1. Load data ──────────────────────────────────────────────────
+    logger.info("Loading canonical dataset")
+    df = pd.read_parquet(INTERIM_DATA_DIR / "expansion_tx.parquet")
+    logger.info(f"Loaded {len(df)} molecules")
+
+    logger.info("Loading cluster CV folds (all 5 repeats)")
+    cluster_folds = pd.read_parquet(INTERIM_DATA_DIR / "cluster_cv_folds.parquet")
+    n_cluster_repeats = cluster_folds["repeat"].nunique()
+    logger.info(f"Cluster folds: {len(cluster_folds)} rows, {n_cluster_repeats} repeats")
+
+    # Skip training if key outputs already exist
+    if (model_dir / "summary_metrics.csv").exists():
+        logger.info(f"Existing {model} outputs found — regenerating figures only")
+        summary_df = pd.read_csv(model_dir / "summary_metrics.csv")
+        repeat_agg = pd.read_csv(model_dir / "repeat_aggregates.csv")
+        var_df = pd.read_csv(model_dir / "variance_summary.csv")
+        _save_figures(summary_df, repeat_agg, var_df, model_dir, dpi, n_random_repeats, n_cluster_repeats)
+        logger.info(f"Figures regenerated in {model_dir}")
+        return
+
+    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+
+    # ── 2. Train and evaluate per strategy per repeat per endpoint ────
+    metric_rows = []
+
+    for ep in ENDPOINTS:
+        ph = ENDPOINT_PH[ep]
+        mask = df[ep].notna().values
+        ep_df = df[mask].copy()
+        n_mol = len(ep_df)
+
+        if n_mol < 50:
+            logger.warning(f"Skipping {ep}: only {n_mol} molecules")
+            continue
+
+        names = ep_df["Molecule Name"].values
+        smiles = ep_df["SMILES"].tolist()
+
+        # Activity values
+        raw_values = ep_df[ep].values
+        if ep in LOG_TRANSFORM_ENDPOINTS:
+            y_all = clip_and_log_transform(raw_values)
+        else:
+            y_all = raw_values
+
+        # Always: protonate (needed for both XGBoost and Chemprop)
+        prot_smiles = protonate_at_ph(smiles, ph)
+
+        # XGBoost only: feature computation (shared across all repeats)
+        if model == "xgboost":
+            ecfp = compute_ecfp4(prot_smiles)
+            desc = compute_rdkit_descriptors(prot_smiles)
+            variance = desc.var(axis=0)
+            desc = desc[:, variance > 0]
+            scaler = StandardScaler()
+            desc_scaled = scaler.fit_transform(desc)
+            X_all = np.hstack([ecfp, desc_scaled])
+            logger.info(f"  {ep} ({n_mol} molecules, {X_all.shape[1]} features)")
+        else:
+            logger.info(f"  {ep} ({n_mol} molecules)")
+
+        # ── Random repeats ────────────────────────────────────────────
+        cache_dir = INTERIM_DATA_DIR / "optuna_cache"
+        for repeat in range(n_random_repeats):
+            fold_ids = make_random_folds(n_mol, n_folds=5, seed=repeat)
+            unique_folds = sorted(set(fold_ids))
+
+            for fold_id in unique_folds:
+                test_mask = fold_ids == fold_id
+                train_mask = ~test_mask
+
+                y_tr = y_all[train_mask]
+                y_te = y_all[test_mask]
+
+                if len(y_te) < 10 or len(y_tr) < 10:
+                    continue
+
+                if model == "xgboost":
+                    X_tr, X_te = X_all[train_mask], X_all[test_mask]
+                    model_obj, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_random_r{repeat}_fold{fold_id}")
+                    y_pred = model_obj.predict(X_te)
+                else:
+                    train_prot = [prot_smiles[i] for i in np.where(train_mask)[0]]
+                    test_prot = [prot_smiles[i] for i in np.where(test_mask)[0]]
+                    y_pred = train_chemprop(train_prot, y_tr, test_prot,
+                                           cache_dir=chemprop_cache,
+                                           cache_key=f"2.12_{ep}_random_r{repeat}_fold{fold_id}")
+
+                mae = mean_absolute_error(y_te, y_pred)
+                r2 = r2_score(y_te, y_pred)
+                sp_r, _ = spearmanr(y_te, y_pred)
+                kt, _ = kendalltau(y_te, y_pred)
+                baseline_mad = np.mean(np.abs(y_te - np.mean(y_te)))
+                rae = mae / baseline_mad if baseline_mad > 0 else np.nan
+
+                metric_rows.append({
+                    "endpoint": ep,
+                    "strategy": "random",
+                    "repeat": repeat,
+                    "fold": fold_id,
+                    "n_train": int(train_mask.sum()),
+                    "n_test": int(test_mask.sum()),
+                    "mae": mae,
+                    "r2": r2,
+                    "spearman_r": sp_r,
+                    "kendall_tau": kt,
+                    "rae": rae,
+                })
+
+        logger.info(f"    random: {n_random_repeats} repeats done")
+
+        # ── Cluster repeats ───────────────────────────────────────────
+        ep_cluster = cluster_folds[cluster_folds["endpoint"] == ep]
+
+        for repeat in range(n_cluster_repeats):
+            rep_folds = ep_cluster[ep_cluster["repeat"] == repeat]
+            fold_map = dict(zip(rep_folds["Molecule Name"], rep_folds["fold"]))
+            fold_ids = np.array([fold_map.get(n, -1) for n in names])
+            unique_folds = sorted(set(fold_ids[fold_ids >= 0]))
+
+            for fold_id in unique_folds:
+                test_mask = fold_ids == fold_id
+                train_mask = (fold_ids >= 0) & ~test_mask
+
+                y_tr = y_all[train_mask]
+                y_te = y_all[test_mask]
+
+                if len(y_te) < 10 or len(y_tr) < 10:
+                    continue
+
+                if model == "xgboost":
+                    X_tr, X_te = X_all[train_mask], X_all[test_mask]
+                    model_obj, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_cluster_r{repeat}_fold{fold_id}")
+                    y_pred = model_obj.predict(X_te)
+                else:
+                    train_prot = [prot_smiles[i] for i in np.where(train_mask)[0]]
+                    test_prot = [prot_smiles[i] for i in np.where(test_mask)[0]]
+                    y_pred = train_chemprop(train_prot, y_tr, test_prot,
+                                           cache_dir=chemprop_cache,
+                                           cache_key=f"2.12_{ep}_cluster_r{repeat}_fold{fold_id}")
+
+                mae = mean_absolute_error(y_te, y_pred)
+                r2 = r2_score(y_te, y_pred)
+                sp_r, _ = spearmanr(y_te, y_pred)
+                kt, _ = kendalltau(y_te, y_pred)
+                baseline_mad = np.mean(np.abs(y_te - np.mean(y_te)))
+                rae = mae / baseline_mad if baseline_mad > 0 else np.nan
+
+                metric_rows.append({
+                    "endpoint": ep,
+                    "strategy": "cluster",
+                    "repeat": repeat,
+                    "fold": fold_id,
+                    "n_train": int(train_mask.sum()),
+                    "n_test": int(test_mask.sum()),
+                    "mae": mae,
+                    "r2": r2,
+                    "spearman_r": sp_r,
+                    "kendall_tau": kt,
+                    "rae": rae,
+                })
+
+        logger.info(f"    cluster: {n_cluster_repeats} repeats done")
+
+    # ── 3. Save per-fold metrics ──────────────────────────────────────
+    summary_df = pd.DataFrame(metric_rows)
+    summary_df.to_csv(model_dir / "summary_metrics.csv", index=False)
+    logger.info(f"Saved summary_metrics.csv ({len(summary_df)} rows)")
+
+    # ── 4. Per-repeat aggregates (mean across folds) ──────────────────
+    repeat_agg = (
+        summary_df.groupby(["endpoint", "strategy", "repeat"])
+        .agg(
+            mae_mean=("mae", "mean"),
+            r2_mean=("r2", "mean"),
+            spearman_r_mean=("spearman_r", "mean"),
+            kendall_tau_mean=("kendall_tau", "mean"),
+            rae_mean=("rae", "mean"),
+        )
+        .reset_index()
+    )
+    repeat_agg.to_csv(model_dir / "repeat_aggregates.csv", index=False)
+    logger.info(f"Saved repeat_aggregates.csv ({len(repeat_agg)} rows)")
+
+    # ── 5. Variance summary per endpoint per strategy ─────────────────
+    var_rows = []
+    for (ep, strategy), grp in repeat_agg.groupby(["endpoint", "strategy"]):
+        row = {"endpoint": ep, "strategy": strategy, "n_repeats": len(grp)}
+        for col in ["mae_mean", "r2_mean", "spearman_r_mean", "kendall_tau_mean", "rae_mean"]:
+            vals = grp[col].values
+            metric_name = col.replace("_mean", "")
+            row[f"{metric_name}_mean"] = np.mean(vals)
+            row[f"{metric_name}_std"] = np.std(vals)
+            row[f"{metric_name}_min"] = np.min(vals)
+            row[f"{metric_name}_max"] = np.max(vals)
+            row[f"{metric_name}_range"] = np.max(vals) - np.min(vals)
+            row[f"{metric_name}_cv"] = np.std(vals) / abs(np.mean(vals)) if np.mean(vals) != 0 else np.nan
+            # 95% CI (using t-distribution approximation for small n)
+            row[f"{metric_name}_ci95"] = 1.96 * np.std(vals) / np.sqrt(len(vals))
+        var_rows.append(row)
+
+    var_df = pd.DataFrame(var_rows)
+    var_df.to_csv(model_dir / "variance_summary.csv", index=False)
+    logger.info("Saved variance_summary.csv")
+
+    for _, row in var_df.iterrows():
+        logger.info(
+            f"  {row['endpoint']} ({row['strategy']}, n={row['n_repeats']}): "
+            f"RAE={row['rae_mean']:.3f}±{row['rae_std']:.3f} "
+            f"[{row['rae_min']:.3f}–{row['rae_max']:.3f}], "
+            f"R²={row['r2_mean']:.3f}±{row['r2_std']:.3f}"
+        )
+
+    # ── 6. Figures ────────────────────────────────────────────────────
+    _save_figures(summary_df, repeat_agg, var_df, model_dir, dpi, n_random_repeats, n_cluster_repeats)
+
+    # ── 7. Mann-Whitney U tests: cluster vs random RAE ─────────────
+    active_endpoints = sorted(repeat_agg["endpoint"].unique())
     logger.info("Computing Mann-Whitney U tests on per-repeat RAE (cluster vs random)")
 
     mw_rows = []
@@ -551,10 +683,10 @@ def main(
         )
 
     mw_df = pd.DataFrame(mw_rows)
-    mw_df.to_csv(output_dir / "mannwhitney_rae_tests.csv", index=False)
+    mw_df.to_csv(model_dir / "mannwhitney_rae_tests.csv", index=False)
     logger.info("Saved mannwhitney_rae_tests.csv")
 
-    logger.info(f"All outputs saved to {output_dir}")
+    logger.info(f"All outputs saved to {model_dir}")
 
 
 if __name__ == "__main__":

--- a/notebooks/2.13-seal-molecular-variants.py
+++ b/notebooks/2.13-seal-molecular-variants.py
@@ -2,23 +2,37 @@
 """Molecular variant consistency analysis (paper Fig S4, ref: Srijit's LinkedIn).
 
 Identifies groups of structurally related molecules (stereoisomers, scaffold
-decorations) and tests whether XGBoost predictions are consistent within groups.
+decorations) and tests whether model predictions are consistent within groups.
 If ECFP fingerprints change significantly for minor structural changes, models
 produce inconsistent predictions — exposing fingerprint artifacts rather than
 learned chemistry.
 
+Supports XGBoost (ECFP4 + RDKit 2D descriptors, Optuna-tuned) and Chemprop
+D-MPNN. Use --combined to generate side-by-side comparison figures once both
+models have been run.
+
 Usage:
     pixi run -e cheminformatics python notebooks/2.13-seal-molecular-variants.py
+    pixi run -e cheminformatics python notebooks/2.13-seal-molecular-variants.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.13-seal-molecular-variants.py --combined
 
-Outputs:
+Model-agnostic outputs (saved directly to output_dir):
     data/processed/2.13-seal-molecular-variants/variant_groups.csv
     data/processed/2.13-seal-molecular-variants/fingerprint_similarity.csv
-    data/processed/2.13-seal-molecular-variants/consistency_metrics.csv
-    data/processed/2.13-seal-molecular-variants/consistency_summary.csv
-    data/processed/2.13-seal-molecular-variants/fingerprint_distances.png
-    data/processed/2.13-seal-molecular-variants/prediction_consistency.png
-    data/processed/2.13-seal-molecular-variants/consistency_heatmap.png
-    data/processed/2.13-seal-molecular-variants/spread_scatter.png
+    data/processed/2.13-seal-molecular-variants/stereoisomer_activity_diffs.csv
+
+Per-model outputs (saved to output_dir/{model}/):
+    data/processed/2.13-seal-molecular-variants/{model}/consistency_metrics.csv
+    data/processed/2.13-seal-molecular-variants/{model}/consistency_summary.csv
+    data/processed/2.13-seal-molecular-variants/{model}/fingerprint_distances.png
+    data/processed/2.13-seal-molecular-variants/{model}/prediction_consistency.png
+    data/processed/2.13-seal-molecular-variants/{model}/consistency_heatmap.png
+    data/processed/2.13-seal-molecular-variants/{model}/spread_scatter.png
+
+Combined outputs:
+    data/processed/2.13-seal-molecular-variants/combined/consistency_comparison.csv
+    data/processed/2.13-seal-molecular-variants/combined/pred_cv_comparison.png
+    data/processed/2.13-seal-molecular-variants/combined/consistency_ratio_comparison.png
 """
 
 from itertools import combinations
@@ -37,9 +51,14 @@ from rdkit.Chem.Scaffolds import MurckoScaffold
 from rdkit.ML.Descriptors.MoleculeDescriptors import MolecularDescriptorCalculator
 from sklearn.preprocessing import StandardScaler
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -160,6 +179,246 @@ def compute_tanimoto_distances_within_group(
     return distances
 
 
+# ── Migration ─────────────────────────────────────────────────────────────────
+
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move pre-model-flag XGBoost outputs into xgboost/ subdirectory."""
+    flat_files = [
+        "consistency_metrics.csv", "consistency_summary.csv",
+        "fingerprint_distances.png", "prediction_consistency.png",
+        "consistency_heatmap.png", "spread_scatter.png",
+    ]
+    xgboost_dir = output_dir / "xgboost"
+    migrated = []
+    for fname in flat_files:
+        src = output_dir / fname
+        dst = xgboost_dir / fname
+        if src.exists() and not dst.exists():
+            xgboost_dir.mkdir(parents=True, exist_ok=True)
+            src.rename(dst)
+            migrated.append(fname)
+    if migrated:
+        logger.info(f"Migrated {len(migrated)} existing files → xgboost/")
+
+
+# ── Per-model figures ─────────────────────────────────────────────────────────
+
+def _generate_figures(
+    consistency_df: pd.DataFrame,
+    summary_df: pd.DataFrame,
+    fp_sim_df: pd.DataFrame,
+    model_dir: Path,
+    dpi: int,
+) -> None:
+    """Generate per-model figures."""
+
+    # Figure A: Fingerprint distance distributions
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4), sharey=True)
+
+    for ax_idx, vtype in enumerate(VARIANT_ORDER):
+        ax = axes[ax_idx]
+        vtype_dists = fp_sim_df[fp_sim_df["variant_type"] == vtype]["tanimoto_distance"].values
+
+        if len(vtype_dists) == 0:
+            ax.set_visible(False)
+            continue
+
+        ax.hist(
+            vtype_dists, bins=50, density=True,
+            color=VARIANT_COLORS[vtype], edgecolor="white", alpha=0.8,
+        )
+        ax.axvline(
+            np.median(vtype_dists), color="black", linestyle="--", alpha=0.7,
+            label=f"median={np.median(vtype_dists):.3f}",
+        )
+        ax.set_xlabel("Tanimoto distance")
+        if ax_idx == 0:
+            ax.set_ylabel("Density")
+        ax.set_title(vtype.replace("_", " ").title(), fontsize=11, fontweight="bold")
+        ax.legend(fontsize=8)
+
+    fig.suptitle(
+        "Intra-group ECFP4 Tanimoto distances by variant type",
+        fontsize=13, y=1.02,
+    )
+    fig.tight_layout()
+    fig.savefig(model_dir / "fingerprint_distances.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved fingerprint_distances.png")
+    plt.close("all")
+
+    # Figure B: Prediction consistency boxplots
+    active_endpoints = sorted(consistency_df["endpoint"].unique())
+    n_ep = len(active_endpoints)
+    nrows = (n_ep + 2) // 3
+    ncols = min(n_ep, 3)
+
+    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4 * nrows))
+    axes = np.atleast_2d(axes).ravel()
+
+    for ax_idx, ep in enumerate(active_endpoints):
+        ax = axes[ax_idx]
+        ep_data = consistency_df[consistency_df["endpoint"] == ep]
+
+        for i, vtype in enumerate(VARIANT_ORDER):
+            vtype_data = ep_data[ep_data["variant_type"] == vtype]["pred_cv"].dropna().values
+            if len(vtype_data) == 0:
+                continue
+            bp = ax.boxplot(
+                vtype_data, positions=[i], widths=0.6,
+                patch_artist=True, showfliers=False,
+            )
+            for patch in bp["boxes"]:
+                patch.set_facecolor(VARIANT_COLORS[vtype])
+                patch.set_alpha(0.7)
+
+        ax.set_xticks(range(len(VARIANT_ORDER)))
+        ax.set_xticklabels(
+            [v.replace("_", "\n") for v in VARIANT_ORDER], fontsize=7,
+        )
+        ax.set_ylabel("Prediction CV", fontsize=9)
+        ax.set_title(ep, fontsize=10, fontweight="bold")
+
+    for i in range(n_ep, len(axes)):
+        axes[i].set_visible(False)
+
+    fig.suptitle(
+        "Within-group prediction CV by variant type and endpoint",
+        fontsize=14, y=1.01,
+    )
+    fig.tight_layout()
+    fig.savefig(model_dir / "prediction_consistency.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved prediction_consistency.png")
+    plt.close("all")
+
+    # Figure C: Consistency summary heatmap
+    fig, ax = plt.subplots(figsize=(10, 7))
+
+    heatmap_data = summary_df.pivot(
+        index="endpoint", columns="variant_type", values="pred_cv_mean",
+    )
+    col_order = [c for c in VARIANT_ORDER if c in heatmap_data.columns]
+    heatmap_data = heatmap_data[col_order]
+
+    annot_data = summary_df.pivot(
+        index="endpoint", columns="variant_type", values="n_groups",
+    )
+    annot_data = annot_data[col_order]
+    annot_arr = np.empty(heatmap_data.shape, dtype=object)
+    for i, ep in enumerate(heatmap_data.index):
+        for j, col in enumerate(col_order):
+            val = heatmap_data.loc[ep, col]
+            n = annot_data.loc[ep, col]
+            if pd.notna(val) and pd.notna(n):
+                annot_arr[i, j] = f"{val:.3f}\n(n={int(n)})"
+            else:
+                annot_arr[i, j] = ""
+
+    sns.heatmap(
+        heatmap_data.astype(float), annot=annot_arr, fmt="",
+        cmap="YlOrRd", ax=ax,
+        cbar_kws={"label": "Mean prediction CV"},
+    )
+    ax.set_title("Prediction consistency: mean CV within variant groups", fontsize=12)
+    ax.set_xlabel("Variant type")
+    ax.set_ylabel("")
+
+    fig.tight_layout()
+    fig.savefig(model_dir / "consistency_heatmap.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved consistency_heatmap.png")
+    plt.close("all")
+
+    # Figure D: Predicted spread vs true spread scatter
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+
+    for ax_idx, vtype in enumerate(VARIANT_ORDER):
+        ax = axes[ax_idx]
+        vtype_data = consistency_df[consistency_df["variant_type"] == vtype]
+
+        if len(vtype_data) == 0:
+            ax.set_visible(False)
+            continue
+
+        ax.scatter(
+            vtype_data["true_range"], vtype_data["pred_range"],
+            color=VARIANT_COLORS[vtype], alpha=0.3, s=15, edgecolors="none",
+        )
+
+        max_val = max(
+            vtype_data["true_range"].max(),
+            vtype_data["pred_range"].max(),
+        )
+        ax.plot([0, max_val], [0, max_val], "k--", alpha=0.4, label="y = x")
+
+        ax.set_xlabel("True activity range")
+        ax.set_ylabel("Predicted range")
+        ax.set_title(vtype.replace("_", " ").title(), fontsize=11, fontweight="bold")
+        ax.legend(fontsize=8)
+
+    fig.suptitle(
+        "Within-group predicted range vs true activity range",
+        fontsize=13, y=1.02,
+    )
+    fig.tight_layout()
+    fig.savefig(model_dir / "spread_scatter.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved spread_scatter.png")
+    plt.close("all")
+
+
+# ── Combined figures ──────────────────────────────────────────────────────────
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Load both models' consistency metrics and produce comparison figures."""
+    xgb_path = output_dir / "xgboost" / "consistency_summary.csv"
+    chemprop_path = output_dir / "chemprop" / "consistency_summary.csv"
+
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    if missing:
+        logger.error(f"Missing results for: {missing}. Run those models first.")
+        return
+
+    combined_dir = output_dir / "combined"
+    combined_dir.mkdir(parents=True, exist_ok=True)
+
+    xgb = pd.read_csv(xgb_path)
+    chemprop = pd.read_csv(chemprop_path)
+
+    # Merge on (variant_type, endpoint) and save comparison CSV
+    merge_cols = ["variant_type", "endpoint", "pred_cv_mean", "pred_cv_median",
+                  "pred_std_mean", "consistency_ratio_mean", "consistency_ratio_median"]
+    comparison_df = (
+        xgb[merge_cols].rename(columns={c: f"{c}_xgboost" for c in merge_cols
+                                        if c not in ("variant_type", "endpoint")})
+        .merge(
+            chemprop[merge_cols].rename(columns={c: f"{c}_chemprop" for c in merge_cols
+                                                 if c not in ("variant_type", "endpoint")}),
+            on=["variant_type", "endpoint"],
+        )
+    )
+    comparison_df.to_csv(combined_dir / "consistency_comparison.csv", index=False)
+    logger.info("Saved consistency_comparison.csv")
+
+    for vtype in VARIANT_ORDER:
+        xgb_vt = xgb[xgb["variant_type"] == vtype].copy()
+        chemprop_vt = chemprop[chemprop["variant_type"] == vtype].copy()
+        if xgb_vt.empty or chemprop_vt.empty:
+            continue
+        vt_data = {"xgboost": xgb_vt, "chemprop": chemprop_vt}
+        vtype_label = vtype.replace("_", " ").title()
+
+        for metric, ylabel, fname in [
+            ("pred_cv_mean", "Mean prediction CV", f"pred_cv_{vtype}"),
+            ("consistency_ratio_mean", "Mean consistency ratio", f"consistency_ratio_{vtype}"),
+        ]:
+            plot_model_comparison_bars(
+                vt_data, "endpoint", metric, ylabel,
+                f"{ylabel} — XGBoost vs Chemprop ({vtype_label})",
+                combined_dir / f"{fname}_comparison.png", dpi=dpi,
+            )
+            logger.info(f"Saved {fname}_comparison.png")
+
+    logger.info(f"Combined figures saved to {combined_dir}")
+
+
 @app.command()
 def main(
     output_dir: Path = typer.Option(
@@ -167,9 +426,24 @@ def main(
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     max_scaffold_group_size: int = typer.Option(20, help="Max scaffold group size for analysis"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if combined:
+        _generate_combined_figures(output_dir, dpi)
+        return
+
+    if model not in ("xgboost", "chemprop"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+        raise typer.Exit(1)
+
+    _migrate_flat_outputs(output_dir)
+
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
 
     # ── 1. Load data ──────────────────────────────────────────────────
     logger.info("Loading canonical dataset")
@@ -221,7 +495,7 @@ def main(
         f"{n_scaffold_mols} molecules ({100 * n_scaffold_mols / len(df):.1f}%)"
     )
 
-    # Save variant group membership
+    # Save variant group membership (model-agnostic)
     group_rows = []
     for group_id, (key, indices) in enumerate(stereo_groups.items()):
         for idx in indices:
@@ -290,7 +564,9 @@ def main(
     stereo_activity_df.to_csv(output_dir / "stereoisomer_activity_diffs.csv", index=False)
     logger.info("Saved stereoisomer_activity_diffs.csv")
 
-    # ── 3. Fingerprint similarity within groups ───────────────────────
+    # ── 3. Fingerprint similarity within groups (model-agnostic) ──────
+    # ECFP4 Tanimoto distances are used for variant group identification.
+    # This is independent of model choice.
     logger.info("Computing intra-group Tanimoto distances")
     fp_sim_rows = []
 
@@ -349,10 +625,30 @@ def main(
         f"median={np.median(random_dists):.3f}"
     )
 
+    # ── Skip training if model outputs already exist ──────────────────
+    if (model_dir / "consistency_metrics.csv").exists():
+        logger.info(f"Existing {model} outputs found — regenerating figures only")
+        consistency_df = pd.read_csv(model_dir / "consistency_metrics.csv")
+        summary_df = pd.read_csv(model_dir / "consistency_summary.csv")
+        _generate_figures(consistency_df, summary_df, fp_sim_df, model_dir, dpi)
+        logger.info(f"All outputs saved to {model_dir}")
+        return
+
     # ── 4. Train and collect out-of-fold predictions ──────────────────
-    logger.info("Training XGBoost models and collecting out-of-fold predictions")
+    logger.info(f"Training {model} models and collecting out-of-fold predictions")
     # Store predictions: molecule_name -> {endpoint -> predicted_value}
     oof_predictions: dict[str, dict[str, float]] = {}
+
+    optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
+    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+
+    # Protonated SMILES per molecule index, keyed by pH (always computed for Chemprop;
+    # for XGBoost this is also the basis for feature computation below).
+    prot_smiles_by_ph: dict[float, list[str]] = {}
+    unique_phs = sorted(set(ENDPOINT_PH.values()))
+    for ph in unique_phs:
+        logger.info(f"Protonating all molecules at pH {ph}")
+        prot_smiles_by_ph[ph] = protonate_at_ph(smiles_all, ph)
 
     for ep in ENDPOINTS:
         ph = ENDPOINT_PH[ep]
@@ -365,23 +661,22 @@ def main(
             continue
 
         ep_names = ep_df["Molecule Name"].values
-        ep_smiles = ep_df["SMILES"].tolist()
-
         raw_values = ep_df[ep].values
         if ep in LOG_TRANSFORM_ENDPOINTS:
             y_all = clip_and_log_transform(raw_values)
         else:
             y_all = raw_values
 
-        # Compute features
-        prot_smiles = protonate_at_ph(ep_smiles, ph)
-        ecfp = compute_ecfp4(prot_smiles)
-        desc = compute_rdkit_descriptors(prot_smiles)
-        variance = desc.var(axis=0)
-        desc = desc[:, variance > 0]
-        scaler = StandardScaler()
-        desc_scaled = scaler.fit_transform(desc)
-        X_all = np.hstack([ecfp, desc_scaled])
+        # ECFP4 + RDKit features: XGBoost training only
+        if model == "xgboost":
+            prot_smiles_ep = [prot_smiles_by_ph[ph][i] for i in np.where(mask)[0]]
+            ecfp = compute_ecfp4(prot_smiles_ep)
+            desc = compute_rdkit_descriptors(prot_smiles_ep)
+            variance = desc.var(axis=0)
+            desc = desc[:, variance > 0]
+            scaler = StandardScaler()
+            desc_scaled = scaler.fit_transform(desc)
+            X_all = np.hstack([ecfp, desc_scaled])
 
         # Get cluster folds for this endpoint
         ep_folds = cluster_folds[cluster_folds["endpoint"] == ep]
@@ -395,15 +690,30 @@ def main(
             test_mask = fold_ids == fold_id
             train_mask = (fold_ids >= 0) & ~test_mask
 
-            X_tr, y_tr = X_all[train_mask], y_all[train_mask]
-            X_te, y_te = X_all[test_mask], y_all[test_mask]
+            y_tr = y_all[train_mask]
+            y_te = y_all[test_mask]
 
             if len(y_te) < 10 or len(y_tr) < 10:
                 continue
 
-            cache_dir = INTERIM_DATA_DIR / "optuna_cache"
-            model, _, _ = tune_xgboost(X_tr, y_tr, cache_dir=cache_dir, cache_key=f"{ep}_cluster_fold{fold_id}")
-            y_pred = model.predict(X_te)
+            if model == "xgboost":
+                X_tr = X_all[train_mask]
+                X_te = X_all[test_mask]
+                model_obj, _, _ = tune_xgboost(
+                    X_tr, y_tr, cache_dir=optuna_cache,
+                    cache_key=f"{ep}_cluster_fold{fold_id}",
+                )
+                y_pred = model_obj.predict(X_te)
+            else:
+                # Chemprop: use protonated SMILES per pH, indexed back to ep subset
+                ep_indices = np.where(mask)[0]
+                train_prot_ep = [prot_smiles_by_ph[ph][ep_indices[i]] for i in np.where(train_mask)[0]]
+                test_prot_ep = [prot_smiles_by_ph[ph][ep_indices[i]] for i in np.where(test_mask)[0]]
+                y_pred = train_chemprop(
+                    train_prot_ep, y_tr, test_prot_ep,
+                    cache_dir=chemprop_cache,
+                    cache_key=f"2.13_{ep}_cluster_fold{fold_id}",
+                )
 
             # Store out-of-fold predictions
             test_names = ep_names[test_mask]
@@ -417,8 +727,6 @@ def main(
     # ── 5. Compute within-group consistency ───────────────────────────
     logger.info("Computing within-group prediction consistency")
     consistency_rows = []
-
-    name_to_idx = {n: i for i, n in enumerate(names_all)}
 
     for vtype, groups in all_variant_groups.items():
         for group_key, indices in groups.items():
@@ -510,7 +818,7 @@ def main(
             })
 
     consistency_df = pd.DataFrame(consistency_rows)
-    consistency_df.to_csv(output_dir / "consistency_metrics.csv", index=False)
+    consistency_df.to_csv(model_dir / "consistency_metrics.csv", index=False)
     logger.info(f"Saved consistency_metrics.csv ({len(consistency_df)} rows)")
 
     # ── 6. Aggregate consistency summary ──────────────────────────────
@@ -531,7 +839,7 @@ def main(
         })
 
     summary_df = pd.DataFrame(summary_rows)
-    summary_df.to_csv(output_dir / "consistency_summary.csv", index=False)
+    summary_df.to_csv(model_dir / "consistency_summary.csv", index=False)
     logger.info("Saved consistency_summary.csv")
 
     for _, row in summary_df.iterrows():
@@ -542,161 +850,10 @@ def main(
             f"consistency_ratio={row['consistency_ratio_mean']:.3f}"
         )
 
-    # ── 7. Figure A: Fingerprint distance distributions ───────────────
-    fig, axes = plt.subplots(1, 3, figsize=(15, 4), sharey=True)
+    # ── 7. Generate figures ───────────────────────────────────────────
+    _generate_figures(consistency_df, summary_df, fp_sim_df, model_dir, dpi)
 
-    for ax_idx, vtype in enumerate(VARIANT_ORDER):
-        ax = axes[ax_idx]
-        vtype_dists = fp_sim_df[fp_sim_df["variant_type"] == vtype]["tanimoto_distance"].values
-
-        if len(vtype_dists) == 0:
-            ax.set_visible(False)
-            continue
-
-        ax.hist(
-            vtype_dists, bins=50, density=True,
-            color=VARIANT_COLORS[vtype], edgecolor="white", alpha=0.8,
-        )
-        ax.axvline(
-            np.median(vtype_dists), color="black", linestyle="--", alpha=0.7,
-            label=f"median={np.median(vtype_dists):.3f}",
-        )
-        ax.set_xlabel("Tanimoto distance")
-        if ax_idx == 0:
-            ax.set_ylabel("Density")
-        ax.set_title(vtype.replace("_", " ").title(), fontsize=11, fontweight="bold")
-        ax.legend(fontsize=8)
-
-    fig.suptitle(
-        "Intra-group ECFP4 Tanimoto distances by variant type",
-        fontsize=13, y=1.02,
-    )
-    fig.tight_layout()
-    fig.savefig(output_dir / "fingerprint_distances.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved fingerprint_distances.png")
-    plt.close("all")
-
-    # ── 8. Figure B: Prediction consistency boxplots ──────────────────
-    active_endpoints = sorted(consistency_df["endpoint"].unique())
-    n_ep = len(active_endpoints)
-    nrows = (n_ep + 2) // 3
-    ncols = min(n_ep, 3)
-
-    fig, axes = plt.subplots(nrows, ncols, figsize=(6 * ncols, 4 * nrows))
-    axes = np.atleast_2d(axes).ravel()
-
-    for ax_idx, ep in enumerate(active_endpoints):
-        ax = axes[ax_idx]
-        ep_data = consistency_df[consistency_df["endpoint"] == ep]
-
-        for i, vtype in enumerate(VARIANT_ORDER):
-            vtype_data = ep_data[ep_data["variant_type"] == vtype]["pred_cv"].dropna().values
-            if len(vtype_data) == 0:
-                continue
-            bp = ax.boxplot(
-                vtype_data, positions=[i], widths=0.6,
-                patch_artist=True, showfliers=False,
-            )
-            for patch in bp["boxes"]:
-                patch.set_facecolor(VARIANT_COLORS[vtype])
-                patch.set_alpha(0.7)
-
-        ax.set_xticks(range(len(VARIANT_ORDER)))
-        ax.set_xticklabels(
-            [v.replace("_", "\n") for v in VARIANT_ORDER], fontsize=7,
-        )
-        ax.set_ylabel("Prediction CV", fontsize=9)
-        ax.set_title(ep, fontsize=10, fontweight="bold")
-
-    for i in range(n_ep, len(axes)):
-        axes[i].set_visible(False)
-
-    fig.suptitle(
-        "Within-group prediction CV by variant type and endpoint",
-        fontsize=14, y=1.01,
-    )
-    fig.tight_layout()
-    fig.savefig(output_dir / "prediction_consistency.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved prediction_consistency.png")
-    plt.close("all")
-
-    # ── 9. Figure C: Consistency summary heatmap ──────────────────────
-    fig, ax = plt.subplots(figsize=(10, 7))
-
-    heatmap_data = summary_df.pivot(
-        index="endpoint", columns="variant_type", values="pred_cv_mean",
-    )
-    # Reorder columns
-    col_order = [c for c in VARIANT_ORDER if c in heatmap_data.columns]
-    heatmap_data = heatmap_data[col_order]
-
-    # Build annotation with group counts
-    annot_data = summary_df.pivot(
-        index="endpoint", columns="variant_type", values="n_groups",
-    )
-    annot_data = annot_data[col_order]
-    annot_arr = np.empty(heatmap_data.shape, dtype=object)
-    for i, ep in enumerate(heatmap_data.index):
-        for j, col in enumerate(col_order):
-            val = heatmap_data.loc[ep, col]
-            n = annot_data.loc[ep, col]
-            if pd.notna(val) and pd.notna(n):
-                annot_arr[i, j] = f"{val:.3f}\n(n={int(n)})"
-            else:
-                annot_arr[i, j] = ""
-
-    sns.heatmap(
-        heatmap_data.astype(float), annot=annot_arr, fmt="",
-        cmap="YlOrRd", ax=ax,
-        cbar_kws={"label": "Mean prediction CV"},
-    )
-    ax.set_title("Prediction consistency: mean CV within variant groups", fontsize=12)
-    ax.set_xlabel("Variant type")
-    ax.set_ylabel("")
-
-    fig.tight_layout()
-    fig.savefig(output_dir / "consistency_heatmap.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved consistency_heatmap.png")
-    plt.close("all")
-
-    # ── 10. Figure D: Predicted spread vs true spread scatter ─────────
-    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
-
-    for ax_idx, vtype in enumerate(VARIANT_ORDER):
-        ax = axes[ax_idx]
-        vtype_data = consistency_df[consistency_df["variant_type"] == vtype]
-
-        if len(vtype_data) == 0:
-            ax.set_visible(False)
-            continue
-
-        ax.scatter(
-            vtype_data["true_range"], vtype_data["pred_range"],
-            color=VARIANT_COLORS[vtype], alpha=0.3, s=15, edgecolors="none",
-        )
-
-        # Diagonal reference line
-        max_val = max(
-            vtype_data["true_range"].max(),
-            vtype_data["pred_range"].max(),
-        )
-        ax.plot([0, max_val], [0, max_val], "k--", alpha=0.4, label="y = x")
-
-        ax.set_xlabel("True activity range")
-        ax.set_ylabel("Predicted range")
-        ax.set_title(vtype.replace("_", " ").title(), fontsize=11, fontweight="bold")
-        ax.legend(fontsize=8)
-
-    fig.suptitle(
-        "Within-group predicted range vs true activity range",
-        fontsize=13, y=1.02,
-    )
-    fig.tight_layout()
-    fig.savefig(output_dir / "spread_scatter.png", dpi=dpi, bbox_inches="tight")
-    logger.info("Saved spread_scatter.png")
-    plt.close("all")
-
-    logger.info(f"All outputs saved to {output_dir}")
+    logger.info(f"All outputs saved to {model_dir}")
 
 
 if __name__ == "__main__":

--- a/notebooks/2.13-seal-molecular-variants.py
+++ b/notebooks/2.13-seal-molecular-variants.py
@@ -713,6 +713,7 @@ def main(
                     train_prot_ep, y_tr, test_prot_ep,
                     cache_dir=chemprop_cache,
                     cache_key=f"2.13_{ep}_cluster_fold{fold_id}",
+                    checkpoint_dir=model_dir / "models",
                 )
 
             # Store out-of-fold predictions

--- a/notebooks/2.15-zalte-resonance-variants.py
+++ b/notebooks/2.15-zalte-resonance-variants.py
@@ -542,6 +542,7 @@ def main(
                     train_prot_fold, y[tr], all_res_smiles,
                     cache_dir=chemprop_cache,
                     cache_key=f"2.15_{ep}_cluster_fold{fold_id}_allres",
+                    checkpoint_dir=model_dir / "models",
                 )
 
                 for name, (s, e) in res_slices.items():

--- a/notebooks/2.15-zalte-resonance-variants.py
+++ b/notebooks/2.15-zalte-resonance-variants.py
@@ -1,5 +1,35 @@
 #!/usr/bin/env python
-"""Molecular variant consistency analysis: Resonance Structures."""
+"""Molecular variant consistency analysis: Resonance Structures.
+
+Analyzes prediction sensitivity to resonance form representation by loading
+pre-generated resonance forms from 2.14, training models (XGBoost or Chemprop),
+and comparing predictions across canonical and resonance-form SMILES.
+
+ECFP4 fingerprint instability analysis (Tanimoto distances between resonance
+forms) is model-agnostic and always computed. Feature computation for XGBoost
+training (ECFP4 + RDKit 2D) is XGBoost-only.
+
+Supports XGBoost (ECFP4 + RDKit 2D descriptors, Optuna-tuned) and Chemprop
+D-MPNN. Use --combined to generate side-by-side comparison figures.
+
+Usage:
+    pixi run -e cheminformatics python notebooks/2.15-zalte-resonance-variants.py
+    pixi run -e cheminformatics python notebooks/2.15-zalte-resonance-variants.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.15-zalte-resonance-variants.py --combined
+
+Model-agnostic outputs (saved to output_dir):
+    data/processed/2.15-zalte-resonance-variants/fingerprint_similarity.csv
+    data/processed/2.15-zalte-resonance-variants/fingerprint_distances.png
+
+Per-model outputs (saved to output_dir/{model}/):
+    data/processed/2.15-zalte-resonance-variants/{model}/consistency_metrics.csv
+    data/processed/2.15-zalte-resonance-variants/{model}/consistency_summary.csv
+    data/processed/2.15-zalte-resonance-variants/{model}/resonance_sensitivity_panel.png
+
+Combined outputs:
+    data/processed/2.15-zalte-resonance-variants/combined/consistency_comparison.csv
+    data/processed/2.15-zalte-resonance-variants/combined/pct_swing_comparison.png
+"""
 
 import json
 from itertools import combinations
@@ -18,9 +48,14 @@ from rdkit.ML.Descriptors.MoleculeDescriptors import MolecularDescriptorCalculat
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
 
+from polaris_generalization.chemprop_utils import train_chemprop
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
-from polaris_generalization.visualization import DEFAULT_DPI, set_style
+from polaris_generalization.visualization import (
+    DEFAULT_DPI,
+    plot_model_comparison_bars,
+    set_style,
+)
 
 RDLogger.DisableLog("rdApp.*")
 
@@ -107,6 +142,200 @@ def compute_tanimoto_distances_within_group(smiles_list):
     return dists
 
 
+# ── Migration ─────────────────────────────────────────────────────────────────
+
+def _migrate_flat_outputs(output_dir: Path) -> None:
+    """Move pre-model-flag XGBoost outputs into xgboost/ subdirectory."""
+    flat_files = [
+        "consistency_metrics.csv", "consistency_summary.csv",
+        "resonance_sensitivity_panel.png",
+    ]
+    xgboost_dir = output_dir / "xgboost"
+    migrated = []
+    for fname in flat_files:
+        src = output_dir / fname
+        dst = xgboost_dir / fname
+        if src.exists() and not dst.exists():
+            xgboost_dir.mkdir(parents=True, exist_ok=True)
+            src.rename(dst)
+            migrated.append(fname)
+    if migrated:
+        logger.info(f"Migrated {len(migrated)} existing files → xgboost/")
+
+
+# ── Per-model figure ──────────────────────────────────────────────────────────
+
+def _generate_figures(
+    consistency_df: pd.DataFrame,
+    ep_metrics: dict,
+    model_dir: Path,
+    dpi: int,
+) -> None:
+    """Generate the RIGR-aligned three-panel resonance sensitivity figure."""
+    import matplotlib.gridspec as gridspec
+
+    summary = pd.DataFrame(list(ep_metrics.values())).sort_values("pct_swing", ascending=False)
+    ep_order = summary["endpoint"].tolist()
+
+    COLOR_A       = "#2F7DBF"
+    COLOR_IMPROV  = "#2D7D3A"
+    COLOR_WORSEN  = "#C0392B"
+    COLOR_BOX     = "#E07B54"
+    COLOR_STRIP   = "#7B2D1E"
+    BAR_EDGE      = "black"
+    BAR_LW        = 0.6
+
+    disp = [ENDPOINT_LABELS.get(ep, ep) for ep in ep_order]
+
+    fig = plt.figure(figsize=(16, 10))
+    gs = gridspec.GridSpec(2, 2, height_ratios=[1, 1.2], hspace=0.28, wspace=0.18)
+
+    y_pos = np.arange(len(ep_order))
+
+    # Panel A: Coverage (top-left)
+    ax_a = fig.add_subplot(gs[0, 0])
+    coverages = [ep_metrics[ep]["coverage_pct"] for ep in ep_order]
+    ax_a.barh(y_pos, coverages, color=COLOR_A, height=0.6,
+              edgecolor=BAR_EDGE, linewidth=BAR_LW)
+    for i, (ep, cov) in enumerate(zip(ep_order, coverages)):
+        n_m = ep_metrics[ep]["n_multi"]
+        n_t = ep_metrics[ep]["n_total"]
+        ax_a.text(cov + 0.8, i, f"{cov:.1f}%  ({n_m}/{n_t})", va="center", fontsize=10,
+                  color="dimgray", clip_on=False)
+    ax_a.set_yticks(y_pos)
+    ax_a.set_yticklabels(disp, fontsize=10)
+    ax_a.set_xlabel("Molecules with multiple resonance forms (%)", fontsize=10)
+    ax_a.set_xlim(0, max(coverages) * 1.35)
+    ax_a.set_title("A", fontsize=16, fontweight="bold", loc="left")
+    ax_a.invert_yaxis()
+    ax_a.grid(False)
+    for spine in ["top", "right"]:
+        ax_a.spines[spine].set_visible(False)
+
+    # Panel B: Diverging improvement/worsening (top-right)
+    ax_b = fig.add_subplot(gs[0, 1])
+    improves_neg = [-ep_metrics[ep]["improve_pct"] for ep in ep_order]
+    worsens      = [ ep_metrics[ep]["worsen_pct"]  for ep in ep_order]
+
+    ax_b.barh(y_pos, improves_neg, color=COLOR_IMPROV, height=0.6,
+              edgecolor=BAR_EDGE, linewidth=BAR_LW, label="Best case")
+    ax_b.barh(y_pos, worsens,      color=COLOR_WORSEN, height=0.6,
+              edgecolor=BAR_EDGE, linewidth=BAR_LW, label="Worst case")
+
+    max_improve = max(abs(v) for v in improves_neg)
+    max_worsen  = max(worsens)
+    ax_b.set_xlim(-max_improve * 1.9, max_worsen * 1.35)
+
+    for i, (imp, wor) in enumerate(zip(improves_neg, worsens)):
+        ax_b.text(imp - 0.2, i, f"{abs(imp):.1f}%", va="center", ha="right",
+                  fontsize=10, color=COLOR_IMPROV, clip_on=False)
+        ax_b.text(wor + 0.2, i, f"{wor:.1f}%", va="center", ha="left",
+                  fontsize=10, color=COLOR_WORSEN, clip_on=False)
+
+    ax_b.axvline(0, color="black", linewidth=1.0)
+    ax_b.set_yticks(y_pos)
+    ax_b.set_yticklabels([""] * len(ep_order))
+    ax_b.set_xlabel("Overall RMSE change (% of baseline)", fontsize=10)
+    ax_b.set_title("B", fontsize=16, fontweight="bold", loc="left")
+    ax_b.legend(loc="lower right", fontsize=8, framealpha=0.95, edgecolor="lightgray")
+    ax_b.invert_yaxis()
+    ax_b.grid(False)
+    for spine in ["top", "right"]:
+        ax_b.spines[spine].set_visible(False)
+
+    # Panel C: Per-molecule severity (bottom, full width)
+    ax_c = fig.add_subplot(gs[1, :])
+
+    plot_df = consistency_df.copy()
+    plot_df["endpoint_label"] = plot_df["endpoint"].map(lambda e: ENDPOINT_LABELS.get(e, e))
+    disp_order = [ENDPOINT_LABELS.get(ep, ep) for ep in ep_order]
+
+    sns.boxplot(
+        data=plot_df,
+        x="endpoint_label", y="mol_pct_swing",
+        order=disp_order,
+        color=COLOR_BOX, width=0.5, showfliers=False,
+        boxprops=dict(edgecolor=BAR_EDGE, linewidth=BAR_LW),
+        medianprops=dict(color=BAR_EDGE, linewidth=1.2),
+        whiskerprops=dict(color=BAR_EDGE, linewidth=BAR_LW),
+        capprops=dict(color=BAR_EDGE, linewidth=BAR_LW),
+        ax=ax_c,
+    )
+    strip_data = pd.concat([
+        g.sample(min(len(g), 200), random_state=42)
+        for _, g in plot_df.groupby("endpoint_label")
+    ], ignore_index=True)
+    sns.stripplot(
+        data=strip_data,
+        x="endpoint_label", y="mol_pct_swing",
+        order=disp_order,
+        color=COLOR_STRIP, size=2.5, alpha=0.5, jitter=True, ax=ax_c,
+    )
+
+    p95 = consistency_df["mol_pct_swing"].quantile(0.95)
+    ax_c.set_ylim(bottom=-p95 * 0.04, top=p95 * 1.3)
+    ax_c.set_xlabel("")
+    ax_c.set_ylabel("Error range across resonance forms\n(% of baseline)", fontsize=10)
+    ax_c.set_title("C", fontsize=16, fontweight="bold", loc="left")
+    ax_c.set_xticklabels(disp_order, rotation=30, ha="right", fontsize=10)
+    ax_c.yaxis.grid(True, linestyle="--", linewidth=0.6, alpha=0.5, color="lightgray")
+    ax_c.set_axisbelow(True)
+    for spine in ["top", "right"]:
+        ax_c.spines[spine].set_visible(False)
+
+    fig.savefig(model_dir / "resonance_sensitivity_panel.png", dpi=dpi, bbox_inches="tight")
+    logger.info("Saved resonance_sensitivity_panel.png")
+    plt.close()
+
+
+# ── Combined figures ──────────────────────────────────────────────────────────
+
+def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
+    """Load both models' consistency summaries and produce comparison figures."""
+    xgb_path = output_dir / "xgboost" / "consistency_summary.csv"
+    chemprop_path = output_dir / "chemprop" / "consistency_summary.csv"
+
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    if missing:
+        logger.error(f"Missing results for: {missing}. Run those models first.")
+        return
+
+    combined_dir = output_dir / "combined"
+    combined_dir.mkdir(parents=True, exist_ok=True)
+
+    xgb = pd.read_csv(xgb_path)
+    chemprop = pd.read_csv(chemprop_path)
+
+    # Comparison CSV
+    merge_cols = ["endpoint", "baseline_rmse", "rms_minrd", "rms_maxrd",
+                  "rms_resrange", "pct_swing", "improve_pct", "worsen_pct"]
+    comparison_df = (
+        xgb[merge_cols].rename(columns={c: f"{c}_xgboost" for c in merge_cols if c != "endpoint"})
+        .merge(
+            chemprop[merge_cols].rename(columns={c: f"{c}_chemprop" for c in merge_cols if c != "endpoint"}),
+            on="endpoint",
+        )
+    )
+    comparison_df.to_csv(combined_dir / "consistency_comparison.csv", index=False)
+    logger.info("Saved consistency_comparison.csv")
+
+    # Grouped bar charts
+    data_by_model = {"xgboost": xgb, "chemprop": chemprop}
+    for metric, ylabel, fname in [
+        ("pct_swing", "% RMSE swing (Max−Min)", "pct_swing_comparison"),
+        ("rms_resrange", "RMS resonance prediction range", "rms_resrange_comparison"),
+        ("worsen_pct", "Worst-case RMSE worsening (%)", "worsen_pct_comparison"),
+    ]:
+        plot_model_comparison_bars(
+            data_by_model, "endpoint", metric, ylabel,
+            f"{ylabel} — XGBoost vs Chemprop",
+            combined_dir / f"{fname}.png", dpi=dpi,
+        )
+        logger.info(f"Saved {fname}.png")
+
+    logger.info(f"Combined figures saved to {combined_dir}")
+
+
 # -----------------------------
 # Main
 # -----------------------------
@@ -116,9 +345,24 @@ def main(
         PROCESSED_DATA_DIR / "2.15-zalte-resonance-variants"
     ),
     dpi: int = typer.Option(DEFAULT_DPI),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
 ):
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if combined:
+        _generate_combined_figures(output_dir, dpi)
+        return
+
+    if model not in ("xgboost", "chemprop"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+        raise typer.Exit(1)
+
+    _migrate_flat_outputs(output_dir)
+
+    model_dir = output_dir / model
+    model_dir.mkdir(parents=True, exist_ok=True)
 
     # 1. Load Core Datasets
     logger.info("Loading core datasets...")
@@ -141,7 +385,9 @@ def main(
     all_smiles = df["SMILES"].tolist()
 
     # -----------------------------
-    # Fingerprint Similarity Analysis
+    # Fingerprint Similarity Analysis (model-agnostic)
+    # ECFP4 is used here for fingerprint instability measurement only.
+    # It is always computed regardless of model choice.
     # -----------------------------
     logger.info("Computing intra-group fingerprint distances...")
     fp_sim_rows = []
@@ -164,7 +410,8 @@ def main(
     random_indices = rng.integers(0, len(all_smiles), size=(n_random_pairs, 2))
 
     for i, j in random_indices:
-        if i == j: continue
+        if i == j:
+            continue
         dists = compute_tanimoto_distances_within_group([all_smiles[i], all_smiles[j]])
         if dists:
             fp_sim_rows.append({
@@ -176,56 +423,89 @@ def main(
     fp_sim_df = pd.DataFrame(fp_sim_rows)
     fp_sim_df.to_csv(output_dir / "fingerprint_similarity.csv", index=False)
 
+    # Fingerprint distances figure (model-agnostic, saved to output_dir)
+    fig, ax = plt.subplots(figsize=(8, 5))
+    colors = {"resonance": "coral", "random": "gray"}
+    for vtype in ["resonance", "random"]:
+        dists = fp_sim_df[fp_sim_df["variant_type"] == vtype]["tanimoto_distance"].values
+        if len(dists) > 0:
+            ax.hist(dists, bins=50, density=True, alpha=0.6, color=colors[vtype],
+                    label=f"{vtype.capitalize()} (median={np.median(dists):.3f})")
+    ax.set_xlabel("ECFP4 Tanimoto Distance")
+    ax.set_ylabel("Density")
+    ax.set_title("Intra-group Fingerprint Distances (Resonance vs. Random Pairs)")
+    ax.legend()
+    ax.grid(False)
+    fig.savefig(output_dir / "fingerprint_distances.png", dpi=dpi, bbox_inches="tight")
+    plt.close()
+
     # -----------------------------
-    # Predictions & Cache
+    # Skip-training check
     # -----------------------------
-    cache_path = output_dir / "raw_predictions_cache.json"
+    if (model_dir / "consistency_metrics.csv").exists():
+        logger.info(f"Existing {model} outputs found — regenerating figures only")
+        consistency_df = pd.read_csv(model_dir / "consistency_metrics.csv")
+        summary_df = pd.read_csv(model_dir / "consistency_summary.csv")
+        ep_metrics = {row["endpoint"]: row.to_dict() for _, row in summary_df.iterrows()}
+        _generate_figures(consistency_df, ep_metrics, model_dir, dpi)
+        logger.info("Done.")
+        return
 
-    if cache_path.exists():
-        logger.info(f"Loading predictions cache from {cache_path}...")
-        with open(cache_path) as f:
-            oof_predictions = json.load(f)
-    else:
-        logger.info("No cache found. Training models...")
-        oof_predictions = {}
-        for ep in tqdm(ENDPOINTS, desc="Evaluating Endpoints"):
-            mask = df[ep].notna()
-            ep_df = df[mask].copy()
-            if len(ep_df) < 50: continue
+    # -----------------------------
+    # Predictions
+    # -----------------------------
+    logger.info(f"Training {model} models...")
+    oof_predictions = {}
 
-            orig_smiles = ep_df["SMILES"].tolist()
-            names = ep_df["Molecule Name"].values
-            y = ep_df[ep].values
+    optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
+    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
 
-            if ep in LOG_TRANSFORM_ENDPOINTS:
-                y = clip_and_log_transform(y)
+    for ep in tqdm(ENDPOINTS, desc="Evaluating Endpoints"):
+        ph = ENDPOINT_PH[ep]
+        mask = df[ep].notna()
+        ep_df = df[mask].copy()
+        if len(ep_df) < 50:
+            continue
 
-            train_smiles = protonate_at_ph(orig_smiles, ENDPOINT_PH[ep])
-            X_fp = compute_bit_fp(train_smiles)
-            X_desc = compute_rdkit_descriptors(train_smiles)
+        orig_smiles = ep_df["SMILES"].tolist()
+        names = ep_df["Molecule Name"].values
+        y = ep_df[ep].values
+
+        if ep in LOG_TRANSFORM_ENDPOINTS:
+            y = clip_and_log_transform(y)
+
+        # Protonated SMILES for training molecules (used by both models)
+        train_smiles_prot = protonate_at_ph(orig_smiles, ph)
+
+        # XGBoost: compute ECFP4 + RDKit features (training features only)
+        if model == "xgboost":
+            X_fp = compute_bit_fp(train_smiles_prot)
+            X_desc = compute_rdkit_descriptors(train_smiles_prot)
             var_mask = X_desc.var(axis=0) > 0
             X_desc = X_desc[:, var_mask]
-
             scaler = StandardScaler()
             X_desc = scaler.fit_transform(X_desc)
             X = np.hstack([X_fp, X_desc])
 
-            # Use endpoint-specific fold assignments
-            ep_folds = cluster_folds[cluster_folds["endpoint"] == ep]
-            fold_map = dict(zip(ep_folds["Molecule Name"], ep_folds["fold"]))
-            fold_ids = np.array([fold_map.get(n, -1) for n in names])
-            unique_folds = sorted(set(fold_ids[fold_ids >= 0]))
+        # Use endpoint-specific fold assignments
+        ep_folds = cluster_folds[cluster_folds["endpoint"] == ep]
+        fold_map = dict(zip(ep_folds["Molecule Name"], ep_folds["fold"]))
+        fold_ids = np.array([fold_map.get(n, -1) for n in names])
+        unique_folds = sorted(set(fold_ids[fold_ids >= 0]))
 
-            for fold_id in unique_folds:
-                te = fold_ids == fold_id
-                tr = (fold_ids >= 0) & ~te
+        for fold_id in unique_folds:
+            te = fold_ids == fold_id
+            tr = (fold_ids >= 0) & ~te
 
-                cache_dir = INTERIM_DATA_DIR / "optuna_cache"
-                model, _, _ = tune_xgboost(X[tr], y[tr], cache_dir=cache_dir, cache_key=f"{ep}_cluster_fold{fold_id}")
-
+            if model == "xgboost":
+                model_obj, _, _ = tune_xgboost(
+                    X[tr], y[tr], cache_dir=optuna_cache,
+                    cache_key=f"{ep}_cluster_fold{fold_id}",
+                )
+                # Predict on each test molecule using all its resonance forms
                 for name, smi_orig, true in zip(names[te], np.array(orig_smiles)[te], y[te]):
                     smi_canon = canonicalize_smiles(smi_orig)
-                    res_forms = resonance_groups[ENDPOINT_PH[ep]].get(smi_canon, [smi_canon])
+                    res_forms = resonance_groups[ph].get(smi_canon, [smi_canon])
 
                     res_desc = compute_rdkit_descriptors(res_forms)
                     Xr = np.hstack([
@@ -233,15 +513,44 @@ def main(
                         scaler.transform(res_desc[:, var_mask])
                     ])
 
-                    preds = model.predict(Xr)
-                    if name not in oof_predictions: oof_predictions[name] = {}
+                    preds = model_obj.predict(Xr)
+                    if name not in oof_predictions:
+                        oof_predictions[name] = {}
                     oof_predictions[name][ep] = {
                         "preds": preds.tolist(),
                         "true": float(true),
                     }
+            else:
+                # Chemprop: train once per fold, predict on all resonance forms in one shot.
+                # Mirrors XGBoost: one model per fold, inference on the full augmented test set.
+                train_prot_fold = [train_smiles_prot[i] for i in np.where(tr)[0]]
 
-        with open(cache_path, "w") as f:
-            json.dump(oof_predictions, f, indent=4)
+                # Build flat list of all resonance forms across test molecules, tracking slices.
+                all_res_smiles: list[str] = []
+                res_slices: dict[str, tuple[int, int]] = {}
+                mol_trues: dict[str, float] = {}
+                for name, smi_orig, true in zip(names[te], np.array(orig_smiles)[te], y[te]):
+                    smi_canon = canonicalize_smiles(smi_orig)
+                    forms_prot = [protonate_at_ph([s], ph)[0]
+                                  for s in resonance_groups[ph].get(smi_canon, [smi_canon])]
+                    res_slices[name] = (len(all_res_smiles), len(all_res_smiles) + len(forms_prot))
+                    all_res_smiles.extend(forms_prot)
+                    mol_trues[name] = float(true)
+
+                # One train_chemprop call — model trained once, predicts on all resonance forms.
+                all_preds = train_chemprop(
+                    train_prot_fold, y[tr], all_res_smiles,
+                    cache_dir=chemprop_cache,
+                    cache_key=f"2.15_{ep}_cluster_fold{fold_id}_allres",
+                )
+
+                for name, (s, e) in res_slices.items():
+                    if name not in oof_predictions:
+                        oof_predictions[name] = {}
+                    oof_predictions[name][ep] = {
+                        "preds": all_preds[s:e].tolist(),
+                        "true": mol_trues[name],
+                    }
 
     # -----------------------------
     # RIGR-aligned metrics
@@ -327,150 +636,16 @@ def main(
         }
 
     consistency_df = pd.DataFrame(rigr_rows)
-    consistency_df.to_csv(output_dir / "consistency_metrics.csv", index=False)
+    consistency_df.to_csv(model_dir / "consistency_metrics.csv", index=False)
 
     summary = pd.DataFrame(list(ep_metrics.values())).sort_values("pct_swing", ascending=False)
-    summary.to_csv(output_dir / "consistency_summary.csv", index=False)
-
-    # Endpoint order: sorted by total pct_swing descending (shared across all panels)
-    ep_order = summary["endpoint"].tolist()
+    summary.to_csv(model_dir / "consistency_summary.csv", index=False)
 
     # -----------------------------
     # Plotting Suite
     # -----------------------------
     logger.info("Generating plots...")
-
-    # 1. Fingerprint Distances (resonance vs random pairs) — standalone figure
-    fig, ax = plt.subplots(figsize=(8, 5))
-    colors = {"resonance": "coral", "random": "gray"}
-    for vtype in ["resonance", "random"]:
-        dists = fp_sim_df[fp_sim_df["variant_type"] == vtype]["tanimoto_distance"].values
-        if len(dists) > 0:
-            ax.hist(dists, bins=50, density=True, alpha=0.6, color=colors[vtype],
-                    label=f"{vtype.capitalize()} (median={np.median(dists):.3f})")
-    ax.set_xlabel("ECFP4 Tanimoto Distance")
-    ax.set_ylabel("Density")
-    ax.set_title("Intra-group Fingerprint Distances (Resonance vs. Random Pairs)")
-    ax.legend()
-    ax.grid(False)
-    fig.savefig(output_dir / "fingerprint_distances.png", dpi=dpi, bbox_inches="tight")
-    plt.close()
-
-    # 2. Three-panel resonance sensitivity figure
-    import matplotlib.gridspec as gridspec
-
-    # Colors
-    COLOR_A       = "#2F7DBF"   # steel blue
-    COLOR_IMPROV  = "#2D7D3A"   # forest green
-    COLOR_WORSEN  = "#C0392B"   # crimson
-    COLOR_BOX     = "#E07B54"   # warm coral
-    COLOR_STRIP   = "#7B2D1E"   # dark rust
-    BAR_EDGE      = "black"
-    BAR_LW        = 0.6
-
-    # Shortened display labels
-    disp = [ENDPOINT_LABELS.get(ep, ep) for ep in ep_order]
-
-    fig = plt.figure(figsize=(16, 10))
-    gs = gridspec.GridSpec(2, 2, height_ratios=[1, 1.2], hspace=0.28, wspace=0.18)
-
-    y_pos = np.arange(len(ep_order))
-
-    # --- Panel A: Coverage (top-left) ---
-    ax_a = fig.add_subplot(gs[0, 0])
-    coverages = [ep_metrics[ep]["coverage_pct"] for ep in ep_order]
-    ax_a.barh(y_pos, coverages, color=COLOR_A, height=0.6,
-              edgecolor=BAR_EDGE, linewidth=BAR_LW)
-    for i, (ep, cov) in enumerate(zip(ep_order, coverages)):
-        n_m = ep_metrics[ep]["n_multi"]
-        n_t = ep_metrics[ep]["n_total"]
-        ax_a.text(cov + 0.8, i, f"{cov:.1f}%  ({n_m}/{n_t})", va="center", fontsize=10,
-                  color="dimgray", clip_on=False)
-    ax_a.set_yticks(y_pos)
-    ax_a.set_yticklabels(disp, fontsize=10)
-    ax_a.set_xlabel("Molecules with multiple resonance forms (%)", fontsize=10)
-    ax_a.set_xlim(0, max(coverages) * 1.35)  # headroom for labels
-    ax_a.set_title("A", fontsize=16, fontweight="bold", loc="left")
-    ax_a.invert_yaxis()
-    ax_a.grid(False)
-    for spine in ["top", "right"]:
-        ax_a.spines[spine].set_visible(False)
-
-    # --- Panel B: Diverging improvement/worsening (top-right) ---
-    ax_b = fig.add_subplot(gs[0, 1])
-    improves_neg = [-ep_metrics[ep]["improve_pct"] for ep in ep_order]
-    worsens      = [ ep_metrics[ep]["worsen_pct"]  for ep in ep_order]
-
-    ax_b.barh(y_pos, improves_neg, color=COLOR_IMPROV, height=0.6,
-              edgecolor=BAR_EDGE, linewidth=BAR_LW, label="Best case")
-    ax_b.barh(y_pos, worsens,      color=COLOR_WORSEN, height=0.6,
-              edgecolor=BAR_EDGE, linewidth=BAR_LW, label="Worst case")
-
-    max_improve = max(abs(v) for v in improves_neg)
-    max_worsen  = max(worsens)
-    ax_b.set_xlim(-max_improve * 1.9, max_worsen * 1.35)
-
-    for i, (imp, wor) in enumerate(zip(improves_neg, worsens)):
-        ax_b.text(imp - 0.2, i, f"{abs(imp):.1f}%", va="center", ha="right",
-                  fontsize=10, color=COLOR_IMPROV, clip_on=False)
-        ax_b.text(wor + 0.2, i, f"{wor:.1f}%", va="center", ha="left",
-                  fontsize=10, color=COLOR_WORSEN, clip_on=False)
-
-    ax_b.axvline(0, color="black", linewidth=1.0)
-    ax_b.set_yticks(y_pos)
-    ax_b.set_yticklabels([""] * len(ep_order))
-    ax_b.set_xlabel("Overall RMSE change (% of baseline)", fontsize=10)
-    ax_b.set_title("B", fontsize=16, fontweight="bold", loc="left")
-    ax_b.legend(loc="lower right", fontsize=8, framealpha=0.95,
-                edgecolor="lightgray")
-    ax_b.invert_yaxis()
-    ax_b.grid(False)
-    for spine in ["top", "right"]:
-        ax_b.spines[spine].set_visible(False)
-
-    # --- Panel C: Per-molecule severity (bottom, full width) ---
-    ax_c = fig.add_subplot(gs[1, :])
-
-    # Map endpoint names in df to display names for x-axis
-    plot_df = consistency_df.copy()
-    plot_df["endpoint_label"] = plot_df["endpoint"].map(lambda e: ENDPOINT_LABELS.get(e, e))
-    disp_order = [ENDPOINT_LABELS.get(ep, ep) for ep in ep_order]
-
-    sns.boxplot(
-        data=plot_df,
-        x="endpoint_label", y="mol_pct_swing",
-        order=disp_order,
-        color=COLOR_BOX, width=0.5, showfliers=False,
-        boxprops=dict(edgecolor=BAR_EDGE, linewidth=BAR_LW),
-        medianprops=dict(color=BAR_EDGE, linewidth=1.2),
-        whiskerprops=dict(color=BAR_EDGE, linewidth=BAR_LW),
-        capprops=dict(color=BAR_EDGE, linewidth=BAR_LW),
-        ax=ax_c,
-    )
-    strip_data = pd.concat([
-        g.sample(min(len(g), 200), random_state=42)
-        for _, g in plot_df.groupby("endpoint_label")
-    ], ignore_index=True)
-    sns.stripplot(
-        data=strip_data,
-        x="endpoint_label", y="mol_pct_swing",
-        order=disp_order,
-        color=COLOR_STRIP, size=2.5, alpha=0.5, jitter=True, ax=ax_c,
-    )
-
-    p95 = consistency_df["mol_pct_swing"].quantile(0.95)
-    ax_c.set_ylim(bottom=-p95 * 0.04, top=p95 * 1.3)
-    ax_c.set_xlabel("")
-    ax_c.set_ylabel("Error range across resonance forms\n(% of baseline)", fontsize=10)
-    ax_c.set_title("C", fontsize=16, fontweight="bold", loc="left")
-    ax_c.set_xticklabels(disp_order, rotation=30, ha="right", fontsize=10)
-    ax_c.yaxis.grid(True, linestyle="--", linewidth=0.6, alpha=0.5, color="lightgray")
-    ax_c.set_axisbelow(True)
-    for spine in ["top", "right"]:
-        ax_c.spines[spine].set_visible(False)
-
-    fig.savefig(output_dir / "resonance_sensitivity_panel.png", dpi=dpi, bbox_inches="tight")
-    plt.close()
+    _generate_figures(consistency_df, ep_metrics, model_dir, dpi)
 
     logger.info("Done.")
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -9,7 +9,10 @@ environments:
       pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aimsim-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/astartes-1.3.3-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.6-hb9c0fe4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.13-h2c9d079_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.6-hb03c661_0.conda
@@ -35,10 +38,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/chemprop-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312h0a2e395_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cuobjdump-12.9.82-hffce074_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cupti-12.9.79-h676940d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvdisasm-12.9.88-hffce074_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvtx-12.9.79-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-12.9.86-h4bc722e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hac629b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/darkdetect-0.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/descriptastorus-2.7.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dill-0.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-abi-3.4.0.100-h3bcb7cf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -49,10 +72,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.62.0-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/freetype-py-2.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/greenlet-3.3.2-py312h8285ef7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.1.1-h6083320_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.5.0-py312h0a2e395_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
@@ -65,15 +96,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-compute-23.0.1-h53684a4_4_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-23.0.1-h635bf11_4_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-23.0.1-hb4dd7c2_4_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h5875eb1_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-1.86.0-hd24cca6_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libboost-python-1.86.0-py312hf890105_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcublas-12.9.1.4-h676940d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcudnn-9.10.2.21-hf7e9902_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcudss-0.7.1.4-h58dd1b1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufft-11.4.1.4-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusolver-11.7.5.82-h676940d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcusparse-12.5.10.65-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
@@ -87,18 +128,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.4-h6548e54_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.39.0-h9d11ab5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.39.0-hdbdcf42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.78.0-h1d1128b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h5e43f62_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.9.0-ha7672b3_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-h9692893_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-23.0.1-h7376487_4_cpu.conda
@@ -111,63 +154,124 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h454ac66_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.10.0-cuda129_mkl_hd6d2a1f_303.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.2-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.2-he237659_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.15.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.4-h4922eb0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.8-py312he3d6523_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mhfp-1.9.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.1-h0e700b2_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mordredcommunity-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.30.4.1-h4d09622_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.2-py312h33ff503_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2025.3.1-hf2ce2f3_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.2-ha668962_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-hbde042b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.5-py312h7f6eeab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.0-py312hd9148b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.3.0-h21090e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/padelpy-0.1.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.1-py312h8ecdadd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-flavor-0.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-23.0.1-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-23.0.1-py312h2054cf2_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py312h2596900_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py312_h9ac99b3_303.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-gpu-2.10.0-cuda129_mkl_h0d04637_303.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-2.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdkit-2025.09.6-py312h3ecb6ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reportlab-4.4.10-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rlpycairo-0.4.0-pyh6c17108_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.0-ha63dd3a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.48-py312h5253ce2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py312h4f23490_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/triton-3.6.0-cuda129py312h811769c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.1-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-ng-2.3.3-hceb46e0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
@@ -179,31 +283,17 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/f9/d721ee039c5d070efbf67696b01aaa84b431b82c7a7e57504f2c1f46ced2/dimorphite_dl-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/aa/85/4890a7c14b4fa54400945cb52ac3cd88545bbdb973c440f98ca41591cdc5/llvmlite-0.46.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/c8/62a253fdb3f66529ed0d7f0e4703fdb44cc8745610f199e173550d8f85eb/more_click-0.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/89/1a74ea99b180b7a5587b0301ed1b183a2937c4b4b67f7994689b5d36fc34/numba-0.64.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/31/1e/9e366f36efc550f07d6737f199e3f6bffafdf28795d007f10a77dd274f5c/nvidia_nccl_cu12-2.29.7-py3-none-manylinux_2_18_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/cb/25fc0914ad183958131f6f549a200b892225b3fad9dcb251062493204e42/pystow-0.8.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/81/68/dddd76117df2ef14c943c6bbb6618be5c9401280046f4ddfc9fb4596a1b8/statsmodels-0.14.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/d2/fcf7192dd1cd8c090b6cfd53fa223c4fb2887a17c47e06bc356d44f40dfb/umap_learn-0.5.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -211,6 +301,8 @@ environments:
       - pypi: ./
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/aimsim-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/astartes-1.3.3-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.9.6-ha02d361_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.9.13-h6ee9776_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.12.6-hc919400_0.conda
@@ -236,10 +328,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-he0f2337_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/chemprop-2.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py312h3093aea_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.28-hb961e35_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/darkdetect-0.8.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/descriptastorus-2.7.0.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dill-0.4.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-abi-3.4.0.100-h485a483_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-2.0.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -250,10 +351,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.62.0-py312h04c11ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.14.2-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/freetype-py-2.3.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.3.0-py312he1ee7cc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/greenlet-3.3.2-py312h6510ced_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.2-hef89b57_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.5.0-py312h3093aea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.22.2-h385eeb1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.18-hdfa7624_0.conda
@@ -309,54 +415,101 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.22.0-h14a376c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.7.1-h4030677_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.10.0-cpu_generic_hf7cc835_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.11.3-h2431656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.6.0-h07db88b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.17.0-hdb1d25a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.2-h5ef1a60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.2-h8d039ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.15.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.0-hc7d1edf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py312h04c11ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.8-py312h605b88b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mhfp-1.9.6-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mordredcommunity-2.0.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nlohmann_json-3.12.0-h784d473_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.4.2-py312he281c53_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.4-hd9e9057_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openldap-2.6.10-hf7f56bc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openpyxl-3.1.5-py312h2a925e6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.1-hd24854e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.0-py312h766f71e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.3.0-hd11884d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-26.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/padelpy-0.1.16-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.1-py312hae6be28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-flavor-0.8.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.9-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py312h4e908a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.4-h81086ad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py312hb3ab3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-23.0.1-py312h1f38498_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-23.0.1-py312h21b41d0_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycairo-1.29.0-py312h2437029_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.10.0-cpu_generic_py312_h2470ad0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-2.6.1-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rdkit-2025.09.6-py312h7e68b95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reportlab-4.4.10-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rlpycairo-0.4.0-pyh6c17108_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py312he5ca3e3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h0f234b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhe01879c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.2.2-hada39a4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlalchemy-2.0.48-py312hb3ab3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py312ha11c99a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.15.0-h396c80c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.15.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py312h2bbb03f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-hc919400_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hc919400_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
@@ -368,30 +521,16 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6d/c1/e419ef3723a074172b68aaa89c9f3de486ed4c2399e2dbd8113a4fdcaf9e/colorlog-6.10.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/f9/d721ee039c5d070efbf67696b01aaa84b431b82c7a7e57504f2c1f46ced2/dimorphite_dl-2.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/f8/4db016a5e547d4e054ff2f3b99203d63a497465f81ab78ec8eb2ff7b2304/llvmlite-0.46.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/21/c8/62a253fdb3f66529ed0d7f0e4703fdb44cc8745610f199e173550d8f85eb/more_click-0.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/a6/9fc52cb4f0d5e6d8b5f4d81615bc01012e3cf24e1052a60f17a68deb8092/numba-0.64.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/32/cb/25fc0914ad183958131f6f549a200b892225b3fad9dcb251062493204e42/pystow-0.8.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/05/30/affbabf3c27fb501ec7b5808230c619d4d1a4525c07301074eb4bda92fa9/statsmodels-0.14.6-cp312-cp312-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/43/d2/fcf7192dd1cd8c090b6cfd53fa223c4fb2887a17c47e06bc356d44f40dfb/umap_learn-0.5.11-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
@@ -906,6 +1045,17 @@ packages:
   purls: []
   size: 28948
   timestamp: 1770939786096
+- conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-7_kmp_llvm.conda
+  build_number: 7
+  sha256: c0cddb66070dd6355311f7667ce2acccf70d1013edaa6e97f22859502fefdb22
+  md5: 887b70e1d607fba7957aa02f9ee0d939
+  depends:
+  - llvm-openmp >=9.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 8244
+  timestamp: 1764092331208
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-7_kmp_llvm.conda
   build_number: 7
   sha256: 7acaa2e0782cad032bdaf756b536874346ac1375745fb250e9bdd6a48a7ab3cd
@@ -917,6 +1067,34 @@ packages:
   purls: []
   size: 8325
   timestamp: 1764092507920
+- conda: https://conda.anaconda.org/conda-forge/noarch/aimsim-2.2.3-pyhd8ed1ab_0.conda
+  sha256: 6769fbbdf19498249e4ae0ad59a5824fe3d8f52d72ce5ec382f34c8e580c2ced
+  md5: 96308b4a2c783154eee2a874dd80b6ae
+  depends:
+  - darkdetect
+  - matplotlib-base
+  - mhfp
+  - mordredcommunity
+  - multiprocess >=0.70
+  - numpy
+  - openpyxl
+  - padelpy
+  - pandas
+  - plotly
+  - psutil
+  - python >=3.8
+  - pyyaml >=5
+  - rdkit
+  - scikit-learn
+  - scipy
+  - seaborn
+  - tabulate
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/aimsim?source=hash-mapping
+  size: 178088
+  timestamp: 1757484213467
 - pypi: https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl
   name: alembic
   version: 1.18.4
@@ -928,11 +1106,38 @@ packages:
   - tomli ; python_full_version < '3.11'
   - tzdata ; extra == 'tz'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+  sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
+  md5: dcdc58c15961dbf17a0621312b01f5cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  purls: []
+  size: 584660
+  timestamp: 1768327524772
 - pypi: https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl
   name: annotated-doc
   version: 0.0.4
   sha256: 571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/noarch/astartes-1.3.3-pyh332efcf_0.conda
+  sha256: 0dcd0d6df10b3fce08a7c921befd8ad3eb224c88fb1487006accaee61d0db6c1
+  md5: 0796a635057bb00e880a691fe389f9c7
+  depends:
+  - numpy
+  - pandas
+  - python >=3.9
+  - scikit-learn
+  - scipy
+  - tabulate
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/astartes?source=hash-mapping
+  size: 36558
+  timestamp: 1759267623189
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.6-hb9c0fe4_1.conda
   sha256: 84f9e2f83d9d93da551e0058c651015dd4bfd84256c6293db01130911c5e0f12
   md5: b1143a5b5a03ee174b3f3f7c49df3c09
@@ -1641,6 +1846,30 @@ packages:
   - pytest ; extra == 'tests'
   - coverage[toml] ; extra == 'tests'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/chemprop-2.2.3-pyhd8ed1ab_0.conda
+  sha256: 24d240107f25d27190f669f530b018925b3f470ca295d23b83842655c69af5cd
+  md5: d9fcf31216acacff6640cb70d1ec2f82
+  depends:
+  - aimsim
+  - astartes
+  - configargparse
+  - descriptastorus
+  - lightning >=2.0
+  - numpy
+  - pandas
+  - python >=3.11,<3.13
+  - pytorch >=2.1
+  - pytorch >=2.1
+  - rdkit
+  - rich
+  - scikit-learn
+  - scipy
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/chemprop?source=hash-mapping
+  size: 111568
+  timestamp: 1774564787651
 - pypi: https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl
   name: click
   version: 8.3.1
@@ -1660,6 +1889,19 @@ packages:
   - pytest ; extra == 'development'
   - types-colorama ; extra == 'development'
   requires_python: '>=3.6'
+- conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.5-pyhcf101f3_0.conda
+  sha256: 7f8ea42a8411b433ec7244dfd30637d90564256c13a114dbe42455fe032ae89c
+  md5: 12389a21e7f69704b0ae77f44355e30b
+  depends:
+  - python >=3.10
+  - toml
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/configargparse?source=hash-mapping
+  size: 45817
+  timestamp: 1773233306055
 - pypi: https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl
   name: contourpy
   version: 1.3.3
@@ -1742,6 +1984,146 @@ packages:
   - pkg:pypi/contourpy?source=compressed-mapping
   size: 286084
   timestamp: 1769156157865
+- conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.13-py312hd8ed1ab_0.conda
+  noarch: generic
+  sha256: d3e9bbd7340199527f28bbacf947702368f31de60c433a16446767d3c6aaf6fe
+  md5: f54c1ffb8ecedb85a8b7fcde3a187212
+  depends:
+  - python >=3.12,<3.13.0a0
+  - python_abi * *_cp312
+  license: Python-2.0
+  purls: []
+  size: 46463
+  timestamp: 1772728929620
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
+  sha256: 2da9964591af14ba11b2379bed01d56e7185260ee0998d1a939add7fb752db45
+  md5: 503a94e20d2690d534d676a764a1852c
+  depends:
+  - cuda-version >=12.9,<12.10.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 29138
+  timestamp: 1753975252445
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
+  sha256: 57d1294ecfaf9dc8cdb5fc4be3e63ebc7614538bddb5de53cfd9b1b7de43aed5
+  md5: cb15315d19b58bd9cd424084e58ad081
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-cudart_linux-64 12.9.79 h3f2d84a_0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 23242
+  timestamp: 1749218416505
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cudart_linux-64-12.9.79-h3f2d84a_0.conda
+  sha256: 6cde0ace2b995b49d0db2eefb7bc30bf00ffc06bb98ef7113632dec8f8907475
+  md5: 64508631775fbbf9eca83c84b1df0cae
+  depends:
+  - cuda-version >=12.9,<12.10.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 197249
+  timestamp: 1749218394213
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cuobjdump-12.9.82-hffce074_1.conda
+  sha256: 113c354cb176eee131cc193507214a471bef73e000f5a143f7367c0e48d92959
+  md5: 55a83761db33f82d92d7d7a4a61662e5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-nvdisasm
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 245074
+  timestamp: 1761107448598
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cupti-12.9.79-h676940d_1.conda
+  sha256: f46c13ab4335281a683f428376cb599019dfd25adafabc39c223824daab7ccae
+  md5: a2ddf359dcb9e6a3d0173b10f58f4db9
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 1841757
+  timestamp: 1761098689894
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvcc-tools-12.9.86-he02047a_2.conda
+  sha256: 0e849be7b5e4832ca218ec2c48a9ba3a15a984f629e2e54f38a53f4f57220341
+  md5: dc256c9864c2e8e9c817fbca1c84a4bc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-crt-tools 12.9.86 ha770c72_2
+  - cuda-nvvm-tools 12.9.86 h4bc722e_2
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=12
+  - libstdcxx >=12
+  constrains:
+  - gcc_impl_linux-64 >=6,<15.0a0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 27380012
+  timestamp: 1753975454194
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvdisasm-12.9.88-hffce074_1.conda
+  sha256: 6851de88381f2ea0cbc5d18a91ae8a8ff6e682c6ee58c03c922902a0c25eb1a7
+  md5: 5e7845d208a5067cb1461a429ff887e0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 5518360
+  timestamp: 1761098730432
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvrtc-12.9.86-hecca717_1.conda
+  sha256: 68f81268c25befa9b70dc49af469ab0eb131960e3700b9a4edb46a32da343a28
+  md5: 53f0062e2243b26e43ddac0b5267c6a3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 67168282
+  timestamp: 1760723629347
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvtx-12.9.79-hecca717_1.conda
+  sha256: b16600e48ef3247366b83d5f195852fcefbc4d52bb245f82a632c7129d1d6283
+  md5: b4a3411fa031c409f98cfbd4b2db9ad7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 29436
+  timestamp: 1761098820386
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-12.9.86-h4bc722e_2.conda
+  sha256: 45f5e881ed0d973132a5475a0b5c066db6e748ef3a831a14dba8374b252e0067
+  md5: f9af26e4079adcd72688a8e8dbecb229
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 24246736
+  timestamp: 1753975332907
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-version-12.9-h4f385c5_3.conda
+  sha256: 5f5f428031933f117ff9f7fcc650e6ea1b3fef5936cf84aa24af79167513b656
+  md5: b6d5d7f1c171cbd228ea06b556cfa859
+  constrains:
+  - cudatoolkit 12.9|12.9.*
+  - __cuda >=12
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 21578
+  timestamp: 1746134436166
 - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
   name: cycler
   version: 0.12.1
@@ -1797,6 +2179,44 @@ packages:
   purls: []
   size: 194397
   timestamp: 1771943557428
+- conda: https://conda.anaconda.org/conda-forge/noarch/darkdetect-0.8.0-pyhd8ed1ab_1.conda
+  sha256: 4874e344117280fb13104864a9474486e998d387a80bc1f288738550411dcf4f
+  md5: 69887bcc8c6f1c439c1376baa6f8dc55
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/darkdetect?source=hash-mapping
+  size: 13566
+  timestamp: 1734328185752
+- conda: https://conda.anaconda.org/conda-forge/noarch/descriptastorus-2.7.0.4-pyhd8ed1ab_1.conda
+  sha256: ed74a69214cc546fff9c15acec43ca069da147e37296d904c817206b0959d3e4
+  md5: 0f93ffc2e9c65225d9aa3be410971d23
+  depends:
+  - pandas-flavor
+  - python >=3.9
+  - rdkit
+  - scipy
+  - tqdm
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/descriptastorus?source=hash-mapping
+  size: 766740
+  timestamp: 1735579415231
+- conda: https://conda.anaconda.org/conda-forge/noarch/dill-0.4.1-pyhcf101f3_0.conda
+  sha256: 1ef84c0cc4efd0c2d58c3cb365945edbd9ee42a1c54514d1ccba4b641005f757
+  md5: 080a808fce955026bf82107d955d32da
+  depends:
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/dill?source=hash-mapping
+  size: 95462
+  timestamp: 1768863743943
 - pypi: https://files.pythonhosted.org/packages/d5/f9/d721ee039c5d070efbf67696b01aaa84b431b82c7a7e57504f2c1f46ced2/dimorphite_dl-2.0.2-py3-none-any.whl
   name: dimorphite-dl
   version: 2.0.2
@@ -1825,6 +2245,50 @@ packages:
   purls: []
   size: 13168
   timestamp: 1771922356515
+- conda: https://conda.anaconda.org/conda-forge/noarch/et_xmlfile-2.0.0-pyhd8ed1ab_1.conda
+  sha256: 2209534fbf2f70c20661ff31f57ab6a97b82ee98812e8a2dcb2b36a0d345727c
+  md5: 71bf9646cbfabf3022c8da4b6b4da737
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/et-xmlfile?source=hash-mapping
+  size: 21908
+  timestamp: 1733749746332
+- conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.29.0-pyhd8ed1ab_0.conda
+  sha256: 6b471a18372bbd52bdf32fc965f71de3bc1b5219418b8e6b3875a67a7b08c483
+  md5: 8fa8358d022a3a9bd101384a808044c6
+  depends:
+  - python >=3.10
+  license: Unlicense
+  purls:
+  - pkg:pypi/filelock?source=compressed-mapping
+  size: 34211
+  timestamp: 1776621506566
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
+  sha256: d4e92ba7a7b4965341dc0fca57ec72d01d111b53c12d11396473115585a9ead6
+  md5: f7d7a4104082b39e3b3473fbd4a38229
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 198107
+  timestamp: 1767681153946
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
+  sha256: dba5d4a93dc62f20e4c2de813ccf7beefed1fb54313faff9c4f2383e4744c8e5
+  md5: ae2f556fbb43e5a75cc80a47ac942a8e
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 180970
+  timestamp: 1767681372955
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -2044,6 +2508,16 @@ packages:
   - pkg:pypi/freetype-py?source=hash-mapping
   size: 58932
   timestamp: 1650983451848
+- conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
+  sha256: 079701b4ff3b317a1a158cabd48cf2b856b8b8d3ef44f152809d9acf20cc8e10
+  md5: 2c11aa96ea85ced419de710c1c3a78ff
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  purls:
+  - pkg:pypi/fsspec?source=compressed-mapping
+  size: 149694
+  timestamp: 1777547807038
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
   sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
   md5: d411fc29e338efb48c5fd4576d71d881
@@ -2067,6 +2541,16 @@ packages:
   purls: []
   size: 82090
   timestamp: 1726600145480
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
+  sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
+  md5: 3bf7b9fd5a7136126e0234db4b87c8b6
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 77248
+  timestamp: 1712692454246
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
   sha256: dc824dc1d0aa358e28da2ecbbb9f03d932d976c8dca11214aa1dcdfcbd054ba2
   md5: ff862eebdfeb2fd048ae9dc92510baca
@@ -2091,6 +2575,72 @@ packages:
   purls: []
   size: 112215
   timestamp: 1718284365403
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
+  md5: c94a5994ef49749880a8139cf9afcbe1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
+  size: 460055
+  timestamp: 1718980856608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
+  sha256: 76e222e072d61c840f64a44e0580c2503562b009090f55aa45053bf1ccb385dd
+  md5: eed7278dfbab727b56f2c0b64330814b
+  depends:
+  - __osx >=11.0
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
+  size: 365188
+  timestamp: 1718981343258
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmpy2-2.3.0-py312hcaba1f9_1.conda
+  sha256: 6fbdd686d04a0d8c48efe92795137d3bba55a4325acd7931978fd8ea5e24684d
+  md5: fedbe80d864debab03541e1b447fc12a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls:
+  - pkg:pypi/gmpy2?source=hash-mapping
+  size: 253171
+  timestamp: 1773245116314
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmpy2-2.3.0-py312he1ee7cc_1.conda
+  sha256: 5f30afd0ef54b4744eb61f71a5ccc9965d9b07830cecc0db9dc6ce73f39b05c4
+  md5: bd0f515e01326c13cc81424233ac7b18
+  depends:
+  - __osx >=11.0
+  - gmp >=6.3.0,<7.0a0
+  - mpc >=1.3.1,<2.0a0
+  - mpfr >=4.2.1,<5.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls:
+  - pkg:pypi/gmpy2?source=hash-mapping
+  size: 194024
+  timestamp: 1773245811244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+  sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
+  md5: 2cd94587f3a401ae05e03a6caf09539d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 99596
+  timestamp: 1755102025473
 - pypi: https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
   name: greenlet
   version: 3.3.2
@@ -2132,6 +2682,26 @@ packages:
   - pkg:pypi/greenlet?source=compressed-mapping
   size: 250518
   timestamp: 1771658526528
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-13.1.1-h6083320_0.conda
+  sha256: cc536468a807a77bbfbbf392a21f205d4e1de1198be03f9359e52e01926d8597
+  md5: 56d73078fe51aee26b7934cb1378d464
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.2,<79.0a0
+  - libexpat >=2.7.4,<3.0a0
+  - libfreetype >=2.14.2
+  - libfreetype6 >=2.14.2
+  - libgcc >=14
+  - libglib >=2.86.4,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 3069804
+  timestamp: 1773391781117
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
   sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
   md5: 186a18e3ba246eccfc7cff00cd19a870
@@ -2169,11 +2739,36 @@ packages:
   version: 2.3.0
   sha256: f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+  sha256: fc9ca7348a4f25fed2079f2153ecdcf5f9cf2a0bc36c4172420ca09e1849df7b
+  md5: 04558c96691bed63104678757beb4f8d
+  depends:
+  - markupsafe >=2.0
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/jinja2?source=compressed-mapping
+  size: 120685
+  timestamp: 1764517220861
 - pypi: https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl
   name: joblib
   version: 1.5.3
   sha256: 5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
+  sha256: 301539229d7be6420c084490b8145583291123f0ce6b92f56be5948a2c83a379
+  md5: 615de2a4d97af50c350e5cf160149e77
+  depends:
+  - python >=3.10
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/joblib?source=hash-mapping
+  size: 226448
+  timestamp: 1765794135253
 - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
   sha256: 0960d06048a7185d3542d850986d807c6e37ca2e644342dd0c72feefcf26c2a4
   md5: b38117a3c920364aff79f870c984b4a3
@@ -2553,24 +3148,25 @@ packages:
   purls: []
   size: 471801
   timestamp: 1773268633092
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-5_h4a7cf45_openblas.conda
-  build_number: 5
-  sha256: 18c72545080b86739352482ba14ba2c4815e19e26a7417ca21a95b76ec8da24c
-  md5: c160954f7418d7b6e87eaf05a8913fa9
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.11.0-6_h5875eb1_mkl.conda
+  build_number: 6
+  sha256: a73ec64c0f60a7733f82a679342bdad88e0230ba8243b12ece13a23aded431f4
+  md5: d03e4571f7876dcd4e530f3d07faf333
   depends:
-  - libopenblas >=0.3.30,<0.3.31.0a0
-  - libopenblas >=0.3.30,<1.0a0
+  - mkl >=2025.3.1,<2026.0a0
   constrains:
-  - mkl <2026
-  - liblapack  3.11.0   5*_openblas
-  - libcblas   3.11.0   5*_openblas
-  - blas 2.305   openblas
-  - liblapacke 3.11.0   5*_openblas
+  - libcblas   3.11.0   6*_mkl
+  - liblapack  3.11.0   6*_mkl
+  - liblapacke 3.11.0   6*_mkl
+  - blas 2.306   mkl
+  track_features:
+  - blas_mkl
+  - blas_mkl_2
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 18213
-  timestamp: 1765818813880
+  size: 18980
+  timestamp: 1774503032324
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.11.0-5_h51639a9_openblas.conda
   build_number: 5
   sha256: 620a6278f194dcabc7962277da6835b1e968e46ad0c8e757736255f5ddbfca8d
@@ -2725,21 +3321,34 @@ packages:
   purls: []
   size: 290754
   timestamp: 1764018009077
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-5_h0358290_openblas.conda
-  build_number: 5
-  sha256: 0cbdcc67901e02dc17f1d19e1f9170610bd828100dc207de4d5b6b8ad1ae7ad8
-  md5: 6636a2b6f1a87572df2970d3ebc87cc0
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-hd0affe5_1.conda
+  sha256: 37c41b1024d0c75da76822e3c079aabaf121618a32fe05e53a897b35a88008fc
+  md5: 499cd8e2d4358986dbe3b30e8fe1bf6a
   depends:
-  - libblas 3.11.0 5_h4a7cf45_openblas
-  constrains:
-  - liblapacke 3.11.0   5*_openblas
-  - blas 2.305   openblas
-  - liblapack  3.11.0   5*_openblas
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 18194
-  timestamp: 1765818837135
+  size: 124432
+  timestamp: 1774333989027
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.11.0-6_hfef963f_mkl.conda
+  build_number: 6
+  sha256: d98a39a8e61af301bf67bf3fb946baff9686864886560cdd48d5259c080c58a5
+  md5: 72cf77ee057f87d826f9b98cacd67a59
+  depends:
+  - libblas 3.11.0 6_h5875eb1_mkl
+  constrains:
+  - liblapack  3.11.0   6*_mkl
+  - liblapacke 3.11.0   6*_mkl
+  - blas 2.306   mkl
+  track_features:
+  - blas_mkl
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 18635
+  timestamp: 1774503047304
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.11.0-5_hb0561ab_openblas.conda
   build_number: 5
   sha256: 38809c361bbd165ecf83f7f05fae9b791e1baa11e4447367f38ae1327f402fc0
@@ -2776,6 +3385,105 @@ packages:
   purls: []
   size: 18765
   timestamp: 1633683992603
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcublas-12.9.1.4-h676940d_1.conda
+  sha256: 671a5204ae983c775d17b3f55b2b0f8ee8cb73b8f0c8b6036070dfadc2770707
+  md5: af0df9bc982b5ed2c67e8f5062d1f8c1
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-nvrtc
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 467746725
+  timestamp: 1761086109565
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcudnn-9.10.2.21-hf7e9902_0.conda
+  sha256: dc6b89e874867b2cdf08224059bd1543cbb72ed646da177c1454596469c9a4bb
+  md5: a178a1f3642521f104ecceeefa138d01
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-nvrtc
+  - cuda-version >=12,<13.0a0
+  - libcublas
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libcudnn-jit <0a
+  license: LicenseRef-cuDNN-Software-License-Agreement
+  purls: []
+  size: 526823453
+  timestamp: 1762823414388
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcudss-0.7.1.4-h58dd1b1_1.conda
+  sha256: 6f2b115c72ea3dc28626f0dbc43d9d5a2e1b391fcca5750750e6f0eafbf8f79c
+  md5: c5b8ea827c65e5811d61aa49cd0bae9a
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - _openmp_mutex >=4.5
+  - cuda-version >=12,<13.0a0
+  - libcublas
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - libcudss0 <0.0.0a0
+  - libcudss-commlayer-nccl 0.7.1.4 h4d09622_1
+  - libcudss-commlayer-mpi 0.7.1.4 h09b4041_1
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 59974143
+  timestamp: 1770671837721
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufft-11.4.1.4-hecca717_1.conda
+  sha256: 62d4214c182c89cfb02271a42eaac56a41f50bbbea3b0d795a8e33f167a39a4e
+  md5: 75ae571353ec92c8f34d4cf6ec6ba264
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 162080769
+  timestamp: 1761098842719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcufile-1.14.1.1-hbc026e6_1.conda
+  sha256: 5fa43e8a8d335fc0c3a6aeb2e7b0debc7d8495b8a60a56ac30f23b0e852ab74a
+  md5: cab1818eada3952ed09c8dcbb7c26af7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - rdma-core >=59.0
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 969845
+  timestamp: 1761098818759
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+  md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.22.2,<1.23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 4518030
+  timestamp: 1770902209173
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurand-10.3.10.19-h676940d_1.conda
+  sha256: 3d40daf956b220cc367a6306ede1e259446fb844051bcfed87c46539cc1aaf03
+  md5: 2a91559a9345bedf09af8b7903deb6e6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 46221876
+  timestamp: 1761098855347
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.19.0-hcf29cc6_0.conda
   sha256: a0390fd0536ebcd2244e243f5f00ab8e76ab62ed9aa214cd54470fe7496620f4
   md5: d50608c443a30c341c24277d28290f76
@@ -2809,6 +3517,34 @@ packages:
   purls: []
   size: 399616
   timestamp: 1773219210246
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcusolver-11.7.5.82-h676940d_2.conda
+  sha256: 8691cf6b1585cf6251663029e00485da5a912f6ca0ff7e5c31a6d8d604b29253
+  md5: bb6e31a0daa64ede76fe8d3fff01c06f
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libcublas >=12.9.1.4,<12.10.0a0
+  - libcusparse >=12.5.10.65,<12.6.0a0
+  - libgcc >=14
+  - libnvjitlink >=12.9.86,<13.0a0
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 205149446
+  timestamp: 1761098826989
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcusparse-12.5.10.65-hecca717_2.conda
+  sha256: 7b511549a22df408d36dadbeabdfd9c35b124d9d6f000b29ffcbe4b38b7faeb7
+  md5: 890ebfaad48c887d3d82847ec9d6bc79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12.9,<12.10.0a0
+  - libgcc >=14
+  - libnvjitlink >=12.9.86,<13.0a0
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
+  purls: []
+  size: 208846028
+  timestamp: 1761069913328
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-22.1.1-h55c6f16_0.conda
   sha256: 3c8142cdd3109c250a926c492ec45bc954697b288e5d1154ada95272ffa21be8
   md5: 7a290d944bc0c481a55baf33fa289deb
@@ -3240,6 +3976,20 @@ packages:
   purls: []
   size: 4867485
   timestamp: 1770641484584
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
+  md5: 0ed3aa3e3e6bc85050d38881673a692f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 2449916
+  timestamp: 1765103845133
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
   sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
   md5: 915f5995e94f60e9a4826e0b0920ee88
@@ -3292,21 +4042,23 @@ packages:
   purls: []
   size: 551197
   timestamp: 1762095054358
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-5_h47877c9_openblas.conda
-  build_number: 5
-  sha256: c723b6599fcd4c6c75dee728359ef418307280fa3e2ee376e14e85e5bbdda053
-  md5: b38076eb5c8e40d0106beda6f95d7609
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.11.0-6_h5e43f62_mkl.conda
+  build_number: 6
+  sha256: 8715428e721a63880d4e548375a744f177200a5161aec3ebe533f33eaf7ec3a5
+  md5: 8b13738802df008211c9ecd08775ca21
   depends:
-  - libblas 3.11.0 5_h4a7cf45_openblas
+  - libblas 3.11.0 6_h5875eb1_mkl
   constrains:
-  - blas 2.305   openblas
-  - liblapacke 3.11.0   5*_openblas
-  - libcblas   3.11.0   5*_openblas
+  - libcblas   3.11.0   6*_mkl
+  - liblapacke 3.11.0   6*_mkl
+  - blas 2.306   mkl
+  track_features:
+  - blas_mkl
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 18200
-  timestamp: 1765818857876
+  size: 18634
+  timestamp: 1774503062183
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.11.0-5_hd9741b5_openblas.conda
   build_number: 5
   sha256: 735a6e6f7d7da6f718b6690b7c0a8ae4815afb89138aa5793abe78128e951dbb
@@ -3345,6 +4097,25 @@ packages:
   purls: []
   size: 92242
   timestamp: 1768752982486
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libmagma-2.9.0-ha7672b3_6.conda
+  sha256: 3a3a7ab6cdafb434157cff2eca6d0ee282b0fcf57ccf618e2c98b4d4fbe43236
+  md5: 7c6ca8cec0c6a213db89a1d80f53d197
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - cuda-cudart
+  - cuda-version >=12,<13.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcublas
+  - libcusparse
+  - libgcc >=14
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 554494928
+  timestamp: 1767140861880
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
   sha256: a4a7dab8db4dc81c736e9a9b42bdfd97b087816e029e221380511960ac46c690
   md5: b499ce4b026493a13774bcf0f4c33849
@@ -3378,6 +4149,17 @@ packages:
   purls: []
   size: 575454
   timestamp: 1756835746393
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
+  sha256: ba7c5d294e3d80f08ac5a39564217702d1a752e352e486210faff794ac5001b4
+  md5: db63358239cbe1ff86242406d440e44a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 741323
+  timestamp: 1731846827427
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
   sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
   md5: d864d34357c3b65a4b731f78c0801dc4
@@ -3408,21 +4190,18 @@ packages:
   purls: []
   size: 31099
   timestamp: 1734670168822
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_4.conda
-  sha256: 199d79c237afb0d4780ccd2fbf829cea80743df60df4705202558675e07dd2c5
-  md5: be43915efc66345cccb3c310b6ed0374
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnvjitlink-12.9.86-hecca717_2.conda
+  sha256: 3b1c851f4fc42d347ce1c1606bdd195343a47f121e0fceb7a1f1e5aa1d497da9
+  md5: 3461b0f2d5cbb7973d361f9e85241d98
   depends:
   - __glibc >=2.17,<3.0.a0
+  - cuda-version >=12,<12.10.0a0
   - libgcc >=14
-  - libgfortran
-  - libgfortran5 >=14.3.0
-  constrains:
-  - openblas >=0.3.30,<0.3.31.0a0
-  license: BSD-3-Clause
-  license_family: BSD
+  - libstdcxx >=14
+  license: LicenseRef-NVIDIA-End-User-License-Agreement
   purls: []
-  size: 5927939
-  timestamp: 1763114673331
+  size: 30515495
+  timestamp: 1760723776293
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_ha158390_4.conda
   sha256: ebbbc089b70bcde87c4121a083c724330f02a690fb9d7c6cd18c30f1b12504fa
   md5: a6f6d3a31bb29e48d37ce65de54e2df0
@@ -3738,6 +4517,17 @@ packages:
   purls: []
   size: 27575
   timestamp: 1771378314494
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.13-hd0affe5_0.conda
+  sha256: c5008b602cb5c819f7b52d418b3ed17e1818cbbf6705b189e7ab36bb70cce3d8
+  md5: 8ee3cb7f64be0e8c4787f3a4dbe024e6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 492799
+  timestamp: 1773797095649
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.22.0-h454ac66_1.conda
   sha256: 4888b9ea2593c36ca587a5ebe38d0a56a0e6d6a9e4bb7da7d9a326aaaca7c336
   md5: 8ed82d90e6b1686f5e98f8b7825a15ef
@@ -3802,6 +4592,91 @@ packages:
   purls: []
   size: 373892
   timestamp: 1762022345545
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtorch-2.10.0-cuda129_mkl_hd6d2a1f_303.conda
+  sha256: 6e6a0d47573bf30ccbab013ba89c00b80fbe8bf86d07aaa7f96e040f98b77e69
+  md5: 5b8a8672aca66f3871aab4d0d1a8f796
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - cuda-cudart >=12.9.79,<13.0a0
+  - cuda-cupti >=12.9.79,<13.0a0
+  - cuda-nvrtc >=12.9.86,<13.0a0
+  - cuda-nvtx >=12.9.79,<13.0a0
+  - cuda-version >=12.9,<13
+  - fmt >=12.1.0,<12.2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libblas * *mkl
+  - libcblas >=3.11.0,<4.0a0
+  - libcublas >=12.9.1.4,<13.0a0
+  - libcudnn >=9.10.2.21,<10.0a0
+  - libcudss >=0.7.1.4,<0.7.2.0a0
+  - libcufft >=11.4.1.4,<12.0a0
+  - libcufile >=1.14.1.1,<2.0a0
+  - libcurand >=10.3.10.19,<11.0a0
+  - libcusolver >=11.7.5.82,<12.0a0
+  - libcusparse >=12.5.10.65,<13.0a0
+  - libgcc >=14
+  - libmagma >=2.9.0,<2.9.1.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=22.1.0
+  - mkl >=2025.3.0,<2026.0a0
+  - nccl >=2.29.3.1,<3.0a0
+  - pybind11-abi 11
+  - sleef >=3.9.0,<4.0a0
+  constrains:
+  - pytorch-gpu 2.10.0
+  - pytorch 2.10.0 cuda129_mkl_*_303
+  - pytorch-cpu <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 815008753
+  timestamp: 1772308092686
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtorch-2.10.0-cpu_generic_hf7cc835_3.conda
+  sha256: a47f1ec77004982a78e3e1533d841bea0930c22594c12bc67e2cb74cd7709b97
+  md5: 98f89ad42eaba858443d31336677aed2
+  depends:
+  - __osx >=11.0
+  - fmt >=12.1.0,<12.2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - liblapack >=3.9.0,<4.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=19.1.7
+  - pybind11-abi 11
+  - sleef >=3.9.0,<4.0a0
+  constrains:
+  - pytorch-cpu 2.10.0
+  - openblas * openmp_*
+  - pytorch-gpu <0.0a0
+  - libopenblas * openmp_*
+  - pytorch 2.10.0 cpu_generic_*_3
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 30298089
+  timestamp: 1772181525404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.13-hd0affe5_0.conda
+  sha256: 1a1e367c04d66030aa93b4d33905f7f6fbb59cfc292e816fe3e9c1e8b3f4d1e2
+  md5: 2c2270f93d6f9073cbf72d821dfc7d72
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 145087
+  timestamp: 1773797108513
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.11.3-hfe17d71_0.conda
   sha256: ecbf4b7520296ed580498dc66a72508b8a79da5126e1d6dc650a7087171288f9
   md5: 1247168fe4a0b8912e3336bccdbf98a5
@@ -3834,6 +4709,27 @@ packages:
   purls: []
   size: 40311
   timestamp: 1766271528534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
+  sha256: c180f4124a889ac343fc59d15558e93667d894a966ec6fdb61da1604481be26b
+  md5: 0f03292cc56bf91a077a134ea8747118
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 895108
+  timestamp: 1753948278280
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.51.0-h6caf38d_1.conda
+  sha256: 042c7488ad97a5629ec0a991a8b2a3345599401ecc75ad6a5af73b60e6db9689
+  md5: c0d87c3c8e075daf1daf6c31b53e8083
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 421195
+  timestamp: 1753948426421
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
   sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
   md5: aea31d2e5b1091feca96fcfe945c3cf9
@@ -3984,6 +4880,54 @@ packages:
   purls: []
   size: 46438
   timestamp: 1727963202283
+- conda: https://conda.anaconda.org/conda-forge/noarch/lightning-2.6.1-pyhcf101f3_0.conda
+  sha256: 38d5f2eab56888ce5f15493e845a099381a1120b7ab0fcfeb1b08029630660f6
+  md5: 45ffefa6c982ae45df735719b8dfe9a1
+  depends:
+  - fsspec <2028.0,>=2022.5.0
+  - lightning-utilities <2.0,>=0.10.0
+  - packaging <27.0,>=23.0
+  - python >=3.10
+  - pytorch <4.0,>=2.1.0
+  - pytorch-lightning
+  - pyyaml <8.0,>5.4
+  - torchmetrics <3.0,>0.7.0
+  - tqdm <6.0,>=4.57.0
+  - typing_extensions <6.0,>4.5.0
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/lightning?source=hash-mapping
+  size: 502687
+  timestamp: 1771191993859
+- conda: https://conda.anaconda.org/conda-forge/noarch/lightning-utilities-0.15.3-pyhd8ed1ab_0.conda
+  sha256: 97dcff433510cfb92f775f6c5da4e18d19ff70d8921187dae0725158946fb3e5
+  md5: 237d294ca3acd678f590f1754e090802
+  depends:
+  - packaging >=17.1
+  - python >=3.10
+  - setuptools
+  - typing_extensions
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/lightning-utilities?source=hash-mapping
+  size: 32379
+  timestamp: 1772138325789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/llvm-openmp-22.1.4-h4922eb0_0.conda
+  sha256: 40e841ae0a03dfb5eaab6479ba0745b3666c869f5a8d066d42a21615933eeb15
+  md5: fa2c5c7f8d5319ab9c9fcbbd04022abf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  constrains:
+  - intel-openmp <0.0a0
+  - openmp 22.1.4|22.1.4.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  purls: []
+  size: 6118643
+  timestamp: 1776845714373
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-22.1.0-hc7d1edf_0.conda
   sha256: 0daeedb3872ad0fdd6f0d7e7165c63488e8a315d7057907434145fba0c1e7b3d
   md5: ff0820b5588b20be3b858552ecf8ffae
@@ -4106,6 +5050,18 @@ packages:
   - pytest-regressions ; extra == 'testing'
   - requests ; extra == 'testing'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+  sha256: 7b1da4b5c40385791dbc3cc85ceea9fad5da680a27d5d3cb8bfaa185e304a89e
+  md5: 5b5203189eb668f042ac2b0826244964
+  depends:
+  - mdurl >=0.1,<1
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/markdown-it-py?source=hash-mapping
+  size: 64736
+  timestamp: 1754951288511
 - pypi: https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: markupsafe
   version: 3.0.3
@@ -4116,6 +5072,38 @@ packages:
   version: 3.0.3
   sha256: 1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+  sha256: 5f3aad1f3a685ed0b591faad335957dbdb1b73abfd6fc731a0d42718e0653b33
+  md5: 93a4752d42b12943a355b682ee43285b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 26057
+  timestamp: 1772445297924
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py312h04c11ed_1.conda
+  sha256: 330394fb9140995b29ae215a19fad46fcc6691bdd1b7654513d55a19aaa091c1
+  md5: 11d95ab83ef0a82cc2de12c1e0b47fe4
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/markupsafe?source=hash-mapping
+  size: 25564
+  timestamp: 1772445846939
 - pypi: https://files.pythonhosted.org/packages/3e/f3/c5195b1ae57ef85339fd7285dfb603b22c8b4e79114bae5f4f0fcf688677/matplotlib-3.10.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: matplotlib
   version: 3.10.8
@@ -4218,6 +5206,64 @@ packages:
   version: 0.1.2
   sha256: 84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
+  sha256: 78c1bbe1723449c52b7a9df1af2ee5f005209f67e40b6e1d3c7619127c43b1c7
+  md5: 592132998493b3ff25fd7479396e8351
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mdurl?source=hash-mapping
+  size: 14465
+  timestamp: 1733255681319
+- conda: https://conda.anaconda.org/conda-forge/noarch/mhfp-1.9.6-pyhd8ed1ab_0.conda
+  sha256: 524ddbe9b0765c458e7fff0ea85de0bdc82a6676eaddde371b24744b401eebdd
+  md5: aea059d859e8d78c898059a22f36b0c2
+  depends:
+  - numpy
+  - python >=3.9
+  - rdkit
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/mhfp?source=hash-mapping
+  size: 15494
+  timestamp: 1735172349460
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mkl-2025.3.1-h0e700b2_11.conda
+  sha256: e03877a111b613dff7b599fd7146def11eb3517f3813e80aedddeb00843f0bf2
+  md5: 1065cab1a38320768d811d740b18b213
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  - llvm-openmp >=22.1.4
+  - onemkl-license 2025.3.1 hf2ce2f3_11
+  - tbb >=2022.3.0
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  size: 125403348
+  timestamp: 1776903785163
+- conda: https://conda.anaconda.org/conda-forge/noarch/mordredcommunity-2.0.7-pyhd8ed1ab_0.conda
+  sha256: f12c872932dda390327c9c0d316d9f2b073a827d870db2f693a3f8ef14afb562
+  md5: 7cf2b58f63cdf92df087894ab423a688
+  depends:
+  - networkx
+  - numpy
+  - packaging
+  - pandas
+  - python >=3.9
+  - rdkit
+  - six
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mordredcommunity?source=hash-mapping
+  size: 133159
+  timestamp: 1769280529199
 - pypi: https://files.pythonhosted.org/packages/21/c8/62a253fdb3f66529ed0d7f0e4703fdb44cc8745610f199e173550d8f85eb/more_click-0.1.3-py3-none-any.whl
   name: more-click
   version: 0.1.3
@@ -4225,6 +5271,95 @@ packages:
   requires_dist:
   - click
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpc-1.4.0-he0a73b1_0.conda
+  sha256: c1fdeebc9f8e4f51df265efca4ea20c7a13911193cc255db73cccb6e422ae486
+  md5: 770d00bf57b5599c4544d61b61d8c6c6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  - mpfr >=4.2.2,<5.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 100245
+  timestamp: 1774472435333
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.4.0-h169892a_0.conda
+  sha256: a9774664adea222e4165efddcd902641c03c7d08fda3a83a5b0885e675ead309
+  md5: 2845c3a1d0d8da1db92aba8323892475
+  depends:
+  - __osx >=11.0
+  - gmp >=6.3.0,<7.0a0
+  - mpfr >=4.2.2,<5.0a0
+  license: LGPL-3.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 86181
+  timestamp: 1774472395307
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.2-he0a73b1_0.conda
+  sha256: 8690f550a780f75d9c47f7ffc15f5ff1c149d36ac17208e50eda101ca16611b9
+  md5: 85ce2ffa51ab21da5efa4a9edc5946aa
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - gmp >=6.3.0,<7.0a0
+  - libgcc >=14
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 730422
+  timestamp: 1773413915171
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.2-h6bc93b0_0.conda
+  sha256: af5eca85f7ffdd403275e916f1de40a7d4b48ae138f12479523d9500c6a073ba
+  md5: a47a14da2103c9c7a390f7c8bc8d7f9b
+  depends:
+  - __osx >=11.0
+  - gmp >=6.3.0,<7.0a0
+  license: LGPL-3.0-only
+  license_family: LGPL
+  purls: []
+  size: 348767
+  timestamp: 1773414111071
+- conda: https://conda.anaconda.org/conda-forge/noarch/mpmath-1.3.0-pyhd8ed1ab_1.conda
+  sha256: 7d7aa3fcd6f42b76bd711182f3776a02bef09a68c5f117d66b712a6d81368692
+  md5: 3585aa87c43ab15b167b574cd73b057b
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/mpmath?source=hash-mapping
+  size: 439705
+  timestamp: 1733302781386
+- conda: https://conda.anaconda.org/conda-forge/linux-64/multiprocess-0.70.19-py312h5253ce2_0.conda
+  sha256: 12e6f7a136ddd7e254d79e18f8815d268967a22e66617b377599fe51dc1269f6
+  md5: 7efbcffe0c84f219ae981478106c55f5
+  depends:
+  - python
+  - dill >=0.4.1
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  size: 368525
+  timestamp: 1769086764893
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/multiprocess-0.70.19-py312hb3ab3e3_0.conda
+  sha256: e6684816e5cd74b664ba2adbcfdbfa9434702690a2ba10f62ed41566ed5b38d1
+  md5: 7aa7f3104e4fe84565e0b9a77086736f
+  depends:
+  - python
+  - dill >=0.4.1
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/multiprocess?source=hash-mapping
+  size: 371957
+  timestamp: 1769086875473
 - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
   sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
   md5: 37293a85a0f4f77bbd9cf7aaefc62609
@@ -4236,6 +5371,31 @@ packages:
   - pkg:pypi/munkres?source=hash-mapping
   size: 15851
   timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-2.20.0-pyhcf101f3_0.conda
+  sha256: 676cbfbf709ce984a14e3af5aef70f1ec94a29ea3fdec477115ae302b34a1a2d
+  md5: 6cac1a50359219d786453c6fef819f98
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/narwhals?source=compressed-mapping
+  size: 283664
+  timestamp: 1776691974709
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nccl-2.30.4.1-h4d09622_0.conda
+  sha256: cda7e6c516e0af5d99721f152860c8793a709ba5c2c2cb209886b17d5f86e663
+  md5: 5f6cad41cf88e7938996445f694d76c6
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - cuda-version >=12,<13.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 299472349
+  timestamp: 1777582121878
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
   sha256: 3fde293232fa3fca98635e1167de6b7c7fda83caf24b9d6c91ec9eefb4f4d586
   md5: 47e340acb35de30501a76c7c799c41d7
@@ -4255,6 +5415,23 @@ packages:
   purls: []
   size: 797030
   timestamp: 1738196177597
+- conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
+  sha256: f6a82172afc50e54741f6f84527ef10424326611503c64e359e25a19a8e4c1c6
+  md5: a2c1eeadae7a309daed9d62c96012a2b
+  depends:
+  - python >=3.11
+  - python
+  constrains:
+  - numpy >=1.25
+  - scipy >=1.11.2
+  - matplotlib-base >=3.8
+  - pandas >=2.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/networkx?source=hash-mapping
+  size: 1587439
+  timestamp: 1765215107045
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h54a6638_1.conda
   sha256: fd2cbd8dfc006c72f45843672664a8e4b99b2f8137654eaae8c3d46dca776f63
   md5: 16c2a0e9c4a166e53632cfca4f68d020
@@ -4275,6 +5452,16 @@ packages:
   purls: []
   size: 137595
   timestamp: 1768670878127
+- conda: https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2
+  sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+  md5: 9a66894dfd07c4510beb6b3f9672ccc0
+  constrains:
+  - mkl <0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3843
+  timestamp: 1582593857545
 - pypi: https://files.pythonhosted.org/packages/70/a6/9fc52cb4f0d5e6d8b5f4d81615bc01012e3cf24e1052a60f17a68deb8092/numba-0.64.0-cp312-cp312-macosx_11_0_arm64.whl
   name: numba
   version: 0.64.0
@@ -4346,6 +5533,61 @@ packages:
   version: 2.29.7
   sha256: ecd0a012051abc20c1aa87328841efa8cade3ced65803046e38c2f03c0891fea
   requires_python: '>=3'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/onemkl-license-2025.3.1-hf2ce2f3_11.conda
+  sha256: 857bfc5bfbb3956e56a1db3f73f8850c95ef2d962d78471bfdc5de2319149fdb
+  md5: 4a1793b78e4309bbdb99bd033226f0d2
+  license: LicenseRef-IntelSimplifiedSoftwareOct2022
+  license_family: Proprietary
+  purls: []
+  size: 39831
+  timestamp: 1776903645764
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.2-ha668962_0.conda
+  sha256: 3825a4c84676a8a5cc23b397a2911e4efa4a805daf2af764153bd904e142ec41
+  md5: a41092b0177362dbe5eb2a18501e86c0
+  depends:
+  - xorg-libx11
+  - xorg-libxext
+  - xorg-libxi
+  - xorg-libxrender
+  - xorg-libxtst
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  - harfbuzz >=12.3.2
+  - fontconfig >=2.17.1,<3.0a0
+  - fonts-conda-ecosystem
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - lcms2 >=2.18,<3.0a0
+  - alsa-lib >=1.2.15.3,<1.3.0a0
+  - libpng >=1.6.55,<1.7.0a0
+  - xorg-libxt >=1.3.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - xorg-libx11 >=1.8.13,<2.0a0
+  - libcups >=2.3.3,<2.4.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  purls: []
+  size: 122465031
+  timestamp: 1771443671180
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-h258754b_0.conda
+  sha256: f6f06243c1a35b6590f06be386bd5cefc5b1773b985a61b7917b93dab4cf18ec
+  md5: a4024e03865a7411c1028eac83d1956c
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.3.1,<2.0a0
+  license: GPL-2.0-or-later WITH Classpath-exception-2.0
+  license_family: GPL
+  purls: []
+  size: 199165105
+  timestamp: 1771443790144
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.4-h55fea9a_0.conda
   sha256: 3900f9f2dbbf4129cf3ad6acf4e4b6f7101390b53843591c53b00f034343bc4d
   md5: 11b3379b191f63139e29c0d19dee24cd
@@ -4404,6 +5646,34 @@ packages:
   purls: []
   size: 843972
   timestamp: 1771970904727
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openpyxl-3.1.5-py312h7f6eeab_3.conda
+  sha256: 04839d313708a6b8c185bc9fcc56ccef985ed91520420c665b5e67b55fd8b5fb
+  md5: 04ab345ef65b88bcbb8ac3d083427bfc
+  depends:
+  - et_xmlfile
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/openpyxl?source=hash-mapping
+  size: 476128
+  timestamp: 1769122092500
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openpyxl-3.1.5-py312h2a925e6_3.conda
+  sha256: 53e786fc1095e5e009958acf7e75c3bb9518e6e6373ed82cddf2b59110712d8d
+  md5: 81e1c2e42e0bed7dc7d412dbb1b53a46
+  depends:
+  - et_xmlfile
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/openpyxl?source=hash-mapping
+  size: 477997
+  timestamp: 1769122700108
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
   sha256: 44c877f8af015332a5d12f5ff0fb20ca32f896526a7d0cdb30c769df1144fb5c
   md5: f61eb8cd60ff9057122a3d338b99c00f
@@ -4427,6 +5697,38 @@ packages:
   purls: []
   size: 3104268
   timestamp: 1769556384749
+- conda: https://conda.anaconda.org/conda-forge/linux-64/optree-0.19.0-py312hd9148b4_0.conda
+  sha256: e5cb326247948543cc2b0495e5da4d9b724ebd6e6b6907c9ed6adc1b969aeb2a
+  md5: 6103697b406b6605e744623d9f3d0e0b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.12
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/optree?source=hash-mapping
+  size: 482838
+  timestamp: 1771868357488
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/optree-0.19.0-py312h766f71e_0.conda
+  sha256: 76ea1f736255aeea8b917ea826a0c186ab267656b156709ca374df5dc8ff4d26
+  md5: a98fa17883d7862ef3049f171a03b9dc
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing-extensions >=4.12
+  license: Apache-2.0
+  license_family: Apache
+  purls:
+  - pkg:pypi/optree?source=hash-mapping
+  size: 429640
+  timestamp: 1771868574672
 - pypi: https://files.pythonhosted.org/packages/ac/24/7c731839566d30dc70556d9824ef17692d896c15e3df627bce8c16f753e1/optuna-4.8.0-py3-none-any.whl
   name: optuna
   version: 4.8.0
@@ -4545,6 +5847,17 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 72010
   timestamp: 1769093650580
+- conda: https://conda.anaconda.org/conda-forge/noarch/padelpy-0.1.16-pyhd8ed1ab_0.conda
+  sha256: 400d96145c0c8fa3d7c7c6de42aa3646333d827dc637f6ada6ac8b14b383af78
+  md5: b997d41c01db69d5b06935c69d9f5879
+  depends:
+  - openjdk
+  - python >=3.6
+  license: AGPL-3.0-only AND LGPL-2.1-only AND MIT
+  purls:
+  - pkg:pypi/padelpy?source=hash-mapping
+  size: 20548470
+  timestamp: 1699816495984
 - pypi: https://files.pythonhosted.org/packages/5c/bd/bf8064d9cfa214294356c2d6702b716d3cf3bb24be59287a6a21e24cae6b/pandas-2.3.3-cp312-cp312-macosx_11_0_arm64.whl
   name: pandas
   version: 2.3.3
@@ -4841,6 +6154,19 @@ packages:
   - pkg:pypi/pandas?source=hash-mapping
   size: 13895708
   timestamp: 1771409075692
+- conda: https://conda.anaconda.org/conda-forge/noarch/pandas-flavor-0.8.1-pyhd8ed1ab_0.conda
+  sha256: aa877e8137b7a8e74dc3def124c2c68dbec239e0b8102e52ece9cf170e082bcc
+  md5: fcfc93cec24fad774448fdca33cdedae
+  depends:
+  - pandas >=0.23
+  - python >=3.10
+  - xarray
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pandas-flavor?source=hash-mapping
+  size: 14196
+  timestamp: 1763886862649
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.9-ha770c72_0.conda
   sha256: 721487cedd6130fc35c9ed219f7952aaadb33102834f3e2dd4cadf113dd39e70
   md5: 9048399267b4e56b122081aad7fda761
@@ -4867,6 +6193,18 @@ packages:
   - pytest-cov ; extra == 'test'
   - scipy ; extra == 'test'
   requires_python: '>=3.6'
+- conda: https://conda.anaconda.org/conda-forge/noarch/patsy-1.0.2-pyhcf101f3_0.conda
+  sha256: 9678f4745e6b82b36fab9657a19665081862268cb079cf9acf878ab2c4fadee9
+  md5: 8678577a52161cc4e1c93fcc18e8a646
+  depends:
+  - numpy >=1.4.0
+  - python >=3.10
+  - python
+  license: BSD-2-Clause AND PSF-2.0
+  purls:
+  - pkg:pypi/patsy?source=hash-mapping
+  size: 193450
+  timestamp: 1760998269054
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
   sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
   md5: 7a3bff861a6583f1889021facefc08b1
@@ -5026,6 +6364,21 @@ packages:
   purls: []
   size: 248045
   timestamp: 1754665282033
+- conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.6.0-pyhd8ed1ab_0.conda
+  sha256: c418d325359fc7a0074cea7f081ef1bce26e114d2da8a0154c5d27ecc87a08e7
+  md5: 3e9427ee186846052e81fadde8ebe96a
+  depends:
+  - narwhals >=1.15.1
+  - packaging
+  - python >=3.10
+  constrains:
+  - ipywidgets >=7.6
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/plotly?source=compressed-mapping
+  size: 5251872
+  timestamp: 1772628857717
 - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
   name: pluggy
   version: 1.6.0
@@ -5040,7 +6393,7 @@ packages:
 - pypi: ./
   name: polaris-generalization
   version: 0.1.0
-  sha256: 53d3c0e58c14711cca7dfab698cc0ca2e9a58bdf4efb610ba4aaedc5f97c67cf
+  sha256: 49a795adb545236b31718748b996c94dc7d049a2da6f7eab4ddec162a2762e3f
   requires_dist:
   - pandas>=2.2
   - numpy>=1.26
@@ -5087,6 +6440,34 @@ packages:
   purls: []
   size: 173220
   timestamp: 1730769371051
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
+  sha256: d834fd656133c9e4eaf63ffe9a117c7d0917d86d89f7d64073f4e3a0020bd8a7
+  md5: dd94c506b119130aef5a9382aed648e7
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=compressed-mapping
+  size: 225545
+  timestamp: 1769678155334
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py312hb3ab3e3_0.conda
+  sha256: 6d0e21c76436374635c074208cfeee62a94d3c37d0527ad67fd8a7615e546a05
+  md5: fd856899666759403b3c16dcba2f56ff
+  depends:
+  - python
+  - __osx >=11.0
+  - python 3.12.* *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/psutil?source=hash-mapping
+  size: 239031
+  timestamp: 1769678393511
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -5183,6 +6564,44 @@ packages:
   - pkg:pypi/pyarrow?source=hash-mapping
   size: 3915948
   timestamp: 1771307781330
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-3.0.1-pyh7a1b43c_0.conda
+  sha256: 2558727093f13d4c30e124724566d16badd7de532fd8ee7483628977117d02be
+  md5: 70ece62498c769280f791e836ac53fff
+  depends:
+  - python >=3.8
+  - pybind11-global ==3.0.1 *_0
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pybind11?source=hash-mapping
+  size: 232875
+  timestamp: 1755953378112
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-abi-11-hc364b38_1.conda
+  sha256: 9e7fe12f727acd2787fb5816b2049cef4604b7a00ad3e408c5e709c298ce8bf1
+  md5: f0599959a2447c1e544e216bddf393fa
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 14671
+  timestamp: 1752769938071
+- conda: https://conda.anaconda.org/conda-forge/noarch/pybind11-global-3.0.1-pyhc7ab6ef_0.conda
+  sha256: f11a5903879fe3a24e0d28329cb2b1945127e85a4cdb444b45545cf079f99e2d
+  md5: fe10b422ce8b5af5dab3740e4084c3f9
+  depends:
+  - python >=3.8
+  - __unix
+  - python
+  constrains:
+  - pybind11-abi ==11
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pybind11-global?source=hash-mapping
+  size: 228871
+  timestamp: 1755953338243
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pycairo-1.29.0-py312h2596900_1.conda
   sha256: 15b5392d2755b771cb6830ae0377ed71bf2bcfd33a347dbc3195df80568ce42c
   md5: 7766c2ad93e65415f4289de684261550
@@ -5222,6 +6641,17 @@ packages:
   requires_dist:
   - colorama>=0.4.6 ; extra == 'windows-terminal'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
+  sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
+  md5: 16c18772b340887160c79a6acc022db0
+  depends:
+  - python >=3.10
+  license: BSD-2-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/pygments?source=compressed-mapping
+  size: 893031
+  timestamp: 1774796815820
 - pypi: https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl
   name: pynndescent
   version: 0.6.0
@@ -5373,6 +6803,138 @@ packages:
   purls: []
   size: 6958
   timestamp: 1752805918820
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-2.10.0-cuda129_mkl_py312_h9ac99b3_303.conda
+  sha256: c146329e9a08d69687daaf17e65a204a500b3ef466e44dd5c0f94bc42ab4c50c
+  md5: 4c500a714fa9e56a8c986c7f11b41fb6
+  depends:
+  - __cuda
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex * *_llvm
+  - _openmp_mutex >=4.5
+  - cuda-cudart >=12.9.79,<13.0a0
+  - cuda-cupti >=12.9.79,<13.0a0
+  - cuda-nvrtc >=12.9.86,<13.0a0
+  - cuda-nvtx >=12.9.79,<13.0a0
+  - cuda-version >=12.9,<13
+  - filelock
+  - fmt >=12.1.0,<12.2.0a0
+  - fsspec
+  - jinja2
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libblas * *mkl
+  - libcblas >=3.11.0,<4.0a0
+  - libcublas >=12.9.1.4,<13.0a0
+  - libcudnn >=9.10.2.21,<10.0a0
+  - libcudss >=0.7.1.4,<0.7.2.0a0
+  - libcufft >=11.4.1.4,<12.0a0
+  - libcufile >=1.14.1.1,<2.0a0
+  - libcurand >=10.3.10.19,<11.0a0
+  - libcusolver >=11.7.5.82,<12.0a0
+  - libcusparse >=12.5.10.65,<13.0a0
+  - libgcc >=14
+  - libmagma >=2.9.0,<2.9.1.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libstdcxx >=14
+  - libtorch 2.10.0 cuda129_mkl_hd6d2a1f_303
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=22.1.0
+  - mkl >=2025.3.0,<2026.0a0
+  - mpmath <1.4
+  - nccl >=2.29.3.1,<3.0a0
+  - networkx
+  - numpy >=1.23,<3
+  - optree >=0.13.0
+  - pybind11 <3.0.2
+  - pybind11-abi 11
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setuptools
+  - sleef >=3.9.0,<4.0a0
+  - sympy >=1.13.3
+  - triton 3.6.0
+  - typing_extensions >=4.10.0
+  constrains:
+  - pytorch-gpu 2.10.0
+  - pytorch-cpu <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/torch?source=hash-mapping
+  size: 24479674
+  timestamp: 1772315696423
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytorch-2.10.0-cpu_generic_py312_h2470ad0_3.conda
+  sha256: 6da6392a6d89f043c914c658cdaf98c49e6860ab7e91a0afcb8463723bca4364
+  md5: b4c7ecd785628fbd767d9cb854ec2c0c
+  depends:
+  - __osx >=11.0
+  - filelock
+  - fmt >=12.1.0,<12.2.0a0
+  - fsspec
+  - jinja2
+  - libabseil * cxx17*
+  - libabseil >=20260107.1,<20260108.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - liblapack >=3.9.0,<4.0a0
+  - libprotobuf >=6.33.5,<6.33.6.0a0
+  - libtorch 2.10.0 cpu_generic_hf7cc835_3
+  - libuv >=1.51.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - llvm-openmp >=19.1.7
+  - mpmath <1.4
+  - networkx
+  - nomkl
+  - numpy >=1.23,<3
+  - optree >=0.13.0
+  - pybind11 <3.0.2
+  - pybind11-abi 11
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - setuptools
+  - sleef >=3.9.0,<4.0a0
+  - sympy >=1.13.3
+  - typing_extensions >=4.10.0
+  constrains:
+  - pytorch-cpu 2.10.0
+  - pytorch-gpu <0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/torch?source=hash-mapping
+  size: 22846148
+  timestamp: 1772185000775
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pytorch-gpu-2.10.0-cuda129_mkl_h0d04637_303.conda
+  sha256: 9807474ce5bbbf81e7a92dd724f38f0dffcfefe5494619c2e94f2df469553bf5
+  md5: 1050dc8cf80cd0a9e63f361c12ee0e82
+  depends:
+  - pytorch 2.10.0 cuda*_mkl*303
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 53576
+  timestamp: 1772317256452
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytorch-lightning-2.6.1-pyhcf101f3_0.conda
+  sha256: 997bbca0f4578ba92159a4ac6f54f5cc9f60a1e5241c66aedbf774f2db025a04
+  md5: e44e84a3b731b1a27cbc75d825db9463
+  depends:
+  - fsspec >=2022.5.0
+  - python >=3.10
+  - packaging >=23.0
+  - pyyaml >5.4
+  - pytorch >=2.1.0
+  - tqdm >=4.57.0
+  - torchmetrics >0.7.0
+  - typing_extensions >4.5.0
+  - lightning-utilities >=0.10.0
+  - python
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/pytorch-lightning?source=hash-mapping
+  size: 500422
+  timestamp: 1769802510053
 - pypi: https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl
   name: pytz
   version: 2026.1.post1
@@ -5387,6 +6949,36 @@ packages:
   version: 6.0.3
   sha256: ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.3-py312h8a5da7c_1.conda
+  sha256: cb142bfd92f6e55749365ddc244294fa7b64db6d08c45b018ff1c658907bfcbf
+  md5: 15878599a87992e44c059731771591cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 198293
+  timestamp: 1770223620706
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.3-py312h04c11ed_1.conda
+  sha256: 737959262d03c9c305618f2d48c7f1691fb996f14ae420bfd05932635c99f873
+  md5: 95a5f0831b5e0b1075bbd80fcffc52ac
+  depends:
+  - __osx >=11.0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyyaml?source=hash-mapping
+  size: 187278
+  timestamp: 1770223990452
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
   sha256: 776363493bad83308ba30bcb88c2552632581b143e8ee25b1982c8c743e73abc
   md5: 353823361b1d27eb3960efb076dfcaf6
@@ -5480,6 +7072,21 @@ packages:
   - pkg:pypi/rdkit?source=hash-mapping
   size: 18794896
   timestamp: 1773046426677
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-61.0-h192683f_0.conda
+  sha256: 8e0b7962cf8bec9a016cd91a6c6dc1f9ebc8e7e316b1d572f7b9047d0de54717
+  md5: d487d93d170e332ab39803e05912a762
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libnl >=3.11.0,<4.0a0
+  - libstdcxx >=14
+  - libsystemd0 >=257.10
+  - libudev1 >=257.10
+  license: Linux-OpenIB
+  license_family: BSD
+  purls: []
+  size: 1268666
+  timestamp: 1769154883613
 - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda
   sha256: 3fc684b81631348540e9a42f6768b871dfeab532d3f47d5c341f1f83e2a2b2b2
   md5: 66a715bc01c77d43aca1f9fcb13dde3c
@@ -5560,6 +7167,21 @@ packages:
   - markdown-it-py>=2.2.0
   - pygments>=2.13.0,<3.0.0
   requires_python: '>=3.8.0'
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-15.0.0-pyhcf101f3_0.conda
+  sha256: 3d6ba2c0fcdac3196ba2f0615b4104e532525ffa1335b50a2878be5ff488814a
+  md5: 0242025a3c804966bf71aa04eee82f66
+  depends:
+  - markdown-it-py >=2.2.0
+  - pygments >=2.13.0,<3.0.0
+  - python >=3.10
+  - typing_extensions >=4.0.0,<5.0.0
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/rich?source=hash-mapping
+  size: 208577
+  timestamp: 1775991661559
 - conda: https://conda.anaconda.org/conda-forge/noarch/rlpycairo-0.4.0-pyh6c17108_0.conda
   sha256: 8d993b1a7d869855a1f6358dcc3de08dbeda9263d8c852d44bfc3900701c1e6c
   md5: cc70086eaf08be7f62fd44842c013916
@@ -5713,6 +7335,48 @@ packages:
   - pooch>=1.8.0 ; extra == 'tests'
   - conda-lock==3.0.1 ; extra == 'maintenance'
   requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda
+  sha256: 23c643c37fafa14ba3f2b7a407126ea5e732a3655ea8157cf9f977098f863448
+  md5: 38decbeae260892040709cafc0514162
+  depends:
+  - python
+  - numpy >=1.24.1
+  - scipy >=1.10.0
+  - joblib >=1.3.0
+  - threadpoolctl >=3.2.0
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - _openmp_mutex >=4.5
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scikit-learn?source=hash-mapping
+  size: 9726193
+  timestamp: 1765801245538
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py312he5ca3e3_1.conda
+  sha256: 5f640a06e001666f9d4dca7cca992f1753e722e9f6e50899d7d250c02ddf7398
+  md5: ed7887c51edfa304c69a424279cec675
+  depends:
+  - python
+  - numpy >=1.24.1
+  - scipy >=1.10.0
+  - joblib >=1.3.0
+  - threadpoolctl >=3.2.0
+  - libcxx >=19
+  - python 3.12.* *_cpython
+  - __osx >=11.0
+  - llvm-openmp >=19.1.7
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scikit-learn?source=hash-mapping
+  size: 9124177
+  timestamp: 1766550900752
 - pypi: https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
   name: scipy
   version: 1.17.1
@@ -5801,6 +7465,52 @@ packages:
   - ruff>=0.12.0 ; extra == 'dev'
   - cython-lint>=0.12.2 ; extra == 'dev'
   requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.17.1-py312h54fa4ab_0.conda
+  sha256: e3ad577361d67f6c078a6a7a3898bf0617b937d44dc4ccd57aa3336f2b5778dd
+  md5: 3e38daeb1fb05a95656ff5af089d2e4c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc >=14
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx >=14
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=hash-mapping
+  size: 17109648
+  timestamp: 1771880675810
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.17.1-py312h0f234b1_0.conda
+  sha256: 7082a8c87ae32b6090681a1376e3335cf23c95608c68a3f96f3581c847f8b840
+  md5: fd035cd01bb171090a990ae4f4143090
+  depends:
+  - __osx >=11.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=19
+  - libgfortran
+  - libgfortran5 >=14.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - numpy <2.7
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/scipy?source=hash-mapping
+  size: 13966986
+  timestamp: 1771881089893
 - pypi: https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl
   name: seaborn
   version: 0.13.2
@@ -5829,6 +7539,46 @@ packages:
   - scipy>=1.7 ; extra == 'stats'
   - statsmodels>=0.12 ; extra == 'stats'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-0.13.2-hd8ed1ab_3.conda
+  noarch: python
+  sha256: ea29a69b14dd6be5cdeeaa551bf50d78cafeaf0351e271e358f9b820fcab4cb0
+  md5: 62afb877ca2c2b4b6f9ecb37320085b6
+  depends:
+  - seaborn-base 0.13.2 pyhd8ed1ab_3
+  - statsmodels >=0.12
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 6876
+  timestamp: 1733730113224
+- conda: https://conda.anaconda.org/conda-forge/noarch/seaborn-base-0.13.2-pyhd8ed1ab_3.conda
+  sha256: f209c9c18187570b85ec06283c72d64b8738f825b1b82178f194f4866877f8aa
+  md5: fd96da444e81f9e6fcaac38590f3dd42
+  depends:
+  - matplotlib-base >=3.4,!=3.6.1
+  - numpy >=1.20,!=1.24.0
+  - pandas >=1.2
+  - python >=3.9
+  - scipy >=1.7
+  constrains:
+  - seaborn =0.13.2=*_3
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/seaborn?source=hash-mapping
+  size: 227843
+  timestamp: 1733730112409
+- conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-82.0.1-pyh332efcf_0.conda
+  sha256: 82088a6e4daa33329a30bc26dc19a98c7c1d3f05c0f73ce9845d4eab4924e9e1
+  md5: 8e194e7b992f99a5015edbd4ebd38efd
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/setuptools?source=compressed-mapping
+  size: 639697
+  timestamp: 1773074868565
 - pypi: https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl
   name: shellingham
   version: 1.5.4
@@ -5851,6 +7601,29 @@ packages:
   - pkg:pypi/six?source=hash-mapping
   size: 18455
   timestamp: 1753199211006
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sleef-3.9.0-ha0421bc_0.conda
+  sha256: 57afc2ab5bdb24cf979964018dddbc5dfaee130b415e6863765e45aed2175ee4
+  md5: e8a0b4f5e82ecacffaa5e805020473cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSL-1.0
+  purls: []
+  size: 1951720
+  timestamp: 1756274576844
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sleef-3.9.0-hb028509_0.conda
+  sha256: 799d0578369e67b6d0d6ecdacada411c259629fc4a500b99703c5e85d0a68686
+  md5: 68f833178f171cfffdd18854c0e9b7f9
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - llvm-openmp >=19.1.7
+  license: BSL-1.0
+  purls: []
+  size: 587027
+  timestamp: 1756274982526
 - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
   sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
   md5: 98b6c9dc80eb87b2519b97bcf7e578dd
@@ -6051,11 +7824,102 @@ packages:
   - numpydoc ; extra == 'docs'
   - pandas-datareader ; extra == 'docs'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/statsmodels-0.14.6-py312h4f23490_0.conda
+  sha256: 0c61eccf3f71b9812da8ced747b1f22bafd6f66f9a64abe06bbe147a03b7322e
+  md5: 423b8676bd6eed60e97097b33f13ea3f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/statsmodels?source=hash-mapping
+  size: 11903737
+  timestamp: 1764983555676
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/statsmodels-0.14.6-py312ha11c99a_0.conda
+  sha256: 18f8711f235e32d793938e1738057e7be1d0bfe98f7d27e3e4b98aa757deae92
+  md5: 31f49265d8de9776cd15b421f24b23e0
+  depends:
+  - __osx >=11.0
+  - numpy <3,>=1.22.3
+  - numpy >=1.23,<3
+  - packaging >=21.3
+  - pandas !=2.1.0,>=1.4
+  - patsy >=0.5.6
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - scipy !=1.9.2,>=1.8
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/statsmodels?source=hash-mapping
+  size: 11537488
+  timestamp: 1764984166760
+- conda: https://conda.anaconda.org/conda-forge/noarch/sympy-1.14.0-pyh2585a3b_106.conda
+  sha256: 1c8057e6875eba958aa8b3c1a072dc9a75d013f209c26fd8125a5ebd3abbec0c
+  md5: 32d866e43b25275f61566b9391ccb7b5
+  depends:
+  - __unix
+  - cpython
+  - gmpy2 >=2.0.8
+  - mpmath >=1.1.0,<1.5
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/sympy?source=hash-mapping
+  size: 4661767
+  timestamp: 1771952371059
+- conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.10.0-pyhcf101f3_0.conda
+  sha256: 3f661e98a09f976775a494488beb3d35ebb00f535b169c6bd891f2e280d55783
+  md5: 3b887b7b3468b0f494b4fad40178b043
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/tabulate?source=hash-mapping
+  size: 43964
+  timestamp: 1772732795746
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+  sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
+  md5: 8f7278ca5f7456a974992a8b34284737
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.12.2,<2.12.3.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 181329
+  timestamp: 1767886632911
 - pypi: https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl
   name: threadpoolctl
   version: 3.6.0
   sha256: 43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
+  sha256: 6016672e0e72c4cf23c0cf7b1986283bd86a9c17e8d319212d78d8e9ae42fdfd
+  md5: 9d64911b31d57ca443e9f1e36b04385f
+  depends:
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/threadpoolctl?source=hash-mapping
+  size: 23869
+  timestamp: 1741878358548
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
   sha256: cafeec44494f842ffeca27e9c8b0c27ed714f93ac77ddadc6aaf726b5554ebac
   md5: cffd3bdd58090148f4cfcd831f4b26ab
@@ -6081,6 +7945,35 @@ packages:
   purls: []
   size: 3127137
   timestamp: 1769460817696
+- conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhcf101f3_3.conda
+  sha256: fd30e43699cb22ab32ff3134d3acf12d6010b5bbaa63293c37076b50009b91f8
+  md5: d0fc809fa4c4d85e959ce4ab6e1de800
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/toml?source=hash-mapping
+  size: 24017
+  timestamp: 1764486833072
+- conda: https://conda.anaconda.org/conda-forge/noarch/torchmetrics-1.9.0-pyhd8ed1ab_0.conda
+  sha256: 5ec00585734d54e3f36dc51fc9d48af19756b473391312fee38a4c287263c402
+  md5: 307ddb12f595fd5910ebd5b98cb00561
+  depends:
+  - lightning-utilities >=0.15.3
+  - numpy >1.20.0
+  - packaging >17.1
+  - python >=3.10
+  - pytorch >=2.0.0
+  - setuptools
+  - typing_extensions
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/torchmetrics?source=hash-mapping
+  size: 398600
+  timestamp: 1773827733172
 - pypi: https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl
   name: tqdm
   version: 4.67.3
@@ -6098,6 +7991,42 @@ packages:
   - requests ; extra == 'telegram'
   - ipywidgets>=6 ; extra == 'notebook'
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/noarch/tqdm-4.67.3-pyh8f84b5b_0.conda
+  sha256: 9ef8e47cf00e4d6dcc114eb32a1504cc18206300572ef14d76634ba29dfe1eb6
+  md5: e5ce43272193b38c2e9037446c1d9206
+  depends:
+  - python >=3.10
+  - __unix
+  - python
+  license: MPL-2.0 and MIT
+  purls:
+  - pkg:pypi/tqdm?source=compressed-mapping
+  size: 94132
+  timestamp: 1770153424136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/triton-3.6.0-cuda129py312h811769c_1.conda
+  sha256: e210e24b90002828b600ede41cc6715aa94a418c7eb76782ec5def489c071c9a
+  md5: 3a6d122ac38a1ec19d14cc34a1878bc0
+  depends:
+  - python
+  - setuptools
+  - cuda-nvcc-tools
+  - cuda-cuobjdump
+  - cuda-cudart
+  - cuda-cupti
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - cuda-version >=12.9,<13
+  - cuda-cupti >=12.9.79,<13.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.7,<1.6.0a0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/triton?source=hash-mapping
+  size: 236000420
+  timestamp: 1771627574109
 - pypi: https://files.pythonhosted.org/packages/4a/91/48db081e7a63bb37284f9fbcefda7c44c277b18b0e13fbc36ea2335b71e6/typer-0.24.1-py3-none-any.whl
   name: typer
   version: 0.24.1
@@ -6210,6 +8139,44 @@ packages:
   - pysocks>=1.5.6,!=1.5.7,<2.0 ; extra == 'socks'
   - backports-zstd>=1.0.0 ; python_full_version < '3.14' and extra == 'zstd'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2026.4.0-pyhc364b38_0.conda
+  sha256: 9f5f5905afea6e0188aa6887aed0809033143343a7af06983f4b390c2286d2d7
+  md5: 099794df685f800c3f319ff4742dc1bb
+  depends:
+  - python >=3.11
+  - numpy >=1.26
+  - packaging >=24.2
+  - pandas >=2.2
+  - python
+  constrains:
+  - bottleneck >=1.4
+  - cartopy >=0.23
+  - cftime >=1.6
+  - dask-core >=2024.6
+  - distributed >=2024.6
+  - flox >=0.9
+  - h5netcdf >=1.3
+  - h5py >=3.11
+  - hdf5 >=1.14
+  - iris >=3.9
+  - matplotlib-base >=3.8
+  - nc-time-axis >=1.4
+  - netcdf4 >=1.6.0
+  - numba >=0.60
+  - numbagg >=0.8
+  - pint >=0.24
+  - pydap >=3.5.0
+  - scipy >=1.13
+  - seaborn-base >=0.13
+  - sparse >=0.15
+  - toolz >=0.12
+  - zarr >=2.18
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/xarray?source=hash-mapping
+  size: 1017999
+  timestamp: 1776122774298
 - pypi: https://files.pythonhosted.org/packages/79/98/679de17c2caa4fd3b0b4386ecf7377301702cb0afb22930a07c142fcb1d8/xgboost-3.2.0-py3-none-manylinux_2_28_x86_64.whl
   name: xgboost
   version: 3.2.0
@@ -6338,6 +8305,46 @@ packages:
   purls: []
   size: 50326
   timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+  sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
+  md5: ba231da7fccf9ea1e768caf5c7099b84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20071
+  timestamp: 1759282564045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 47179
+  timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
+  md5: e192019153591938acf7322b6459d36e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 30456
+  timestamp: 1769445263457
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
   sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
   md5: 96d57aba173e878a2089d5638016dc5e
@@ -6350,6 +8357,55 @@ packages:
   purls: []
   size: 33005
   timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-hb9d3cd8_0.conda
+  sha256: a8afba4a55b7b530eb5c8ad89737d60d60bc151a03fbef7a2182461256953f0e
+  md5: 279b0de5f6ba95457190a1c459a64e31
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 379686
+  timestamp: 1731860547604
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 32808
+  timestamp: 1727964811275
+- conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
+  sha256: 6d9ea2f731e284e9316d95fa61869fe7bbba33df7929f82693c121022810f4ad
+  md5: a77f85f77be52ff59391544bfe73390a
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 85189
+  timestamp: 1753484064210
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
+  sha256: b03433b13d89f5567e828ea9f1a7d5c5d697bf374c28a4168d71e9464f5dafac
+  md5: 78a0fe9e9c50d2c381e8ee47e3ea437d
+  depends:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 83386
+  timestamp: 1753484079473
 - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
   sha256: 5d7c0e5f0005f74112a34a7425179f4eb6e73c92f5d109e6af4ddeca407c92ab
   md5: c9f075ab2f33b3bbee9e62d4ad0a6cd8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,13 @@ download = "bash scripts/download_data.sh"
 [tool.pixi.feature.cheminformatics.dependencies]
 rdkit = ">=2024.03"
 pyarrow = ">=14"
+chemprop = ">=2.2"
+
+[tool.pixi.feature.cheminformatics.system-requirements]
+cuda = "12"
+
+[tool.pixi.feature.cheminformatics.target.linux-64.dependencies]
+pytorch-gpu = ">=2.0"
 
 [tool.pixi.environments]
 lint = { features = ["lint"] }

--- a/src/polaris_generalization/chemprop_utils.py
+++ b/src/polaris_generalization/chemprop_utils.py
@@ -9,6 +9,7 @@ from loguru import logger
 # Default training duration. Chemprop's own default is 50; increase for longer runs.
 DEFAULT_MAX_EPOCHS = 50
 ENSEMBLE_SIZE = 3
+MIN_VAL_FOR_EARLY_STOPPING = 5  # Skip early stopping if val set is smaller
 
 
 def train_chemprop(
@@ -66,6 +67,9 @@ def train_chemprop(
 
     from lightning.pytorch.callbacks import EarlyStopping
 
+    accelerator = "gpu" if torch.cuda.is_available() else "cpu"
+    devices = [0] if torch.cuda.is_available() else "auto"
+
     featurizer = featurizers.SimpleMoleculeMolGraphFeaturizer()
     test_pts = [data.MoleculeDatapoint.from_smi(smi) for smi in test_smiles]
 
@@ -96,10 +100,7 @@ def train_chemprop(
         val_idx = rng.choice(n_total, size=n_val, replace=False)
         train_idx = np.setdiff1d(np.arange(n_total), val_idx)
 
-        all_pts = [
-            data.MoleculeDatapoint.from_smi(smi, [float(y)])
-            for smi, y in zip(train_smiles, train_y)
-        ]
+        all_pts = [data.MoleculeDatapoint.from_smi(smi, [float(y)]) for smi, y in zip(train_smiles, train_y)]
         train_pts = [all_pts[j] for j in train_idx]
         val_pts = [all_pts[j] for j in val_idx]
 
@@ -121,21 +122,27 @@ def train_chemprop(
         test_loader = data.build_dataloader(test_dset, shuffle=False, num_workers=4)
 
         best_weights = _BestWeights()
-        early_stop = EarlyStopping(monitor="val_loss", patience=10, mode="min")
+        callbacks = [best_weights]
+        if n_val >= MIN_VAL_FOR_EARLY_STOPPING:
+            callbacks.append(EarlyStopping(monitor="val_loss", patience=10, mode="min"))
+        else:
+            logger.warning(f"Val set too small ({n_val} samples), skipping early stopping")
 
         trainer = pl.Trainer(
             logger=False,
             enable_checkpointing=False,
             enable_progress_bar=True,
             enable_model_summary=False,
-            accelerator="auto",
-            devices=[0],
+            accelerator=accelerator,
+            devices=devices,
             max_epochs=max_epochs,
-            callbacks=[early_stop, best_weights],
+            callbacks=callbacks,
         )
         trainer.fit(mpnn, train_loader, val_loader)
         n_epochs_trained = min(trainer.current_epoch + 1, max_epochs)
-        logger.info(f"Chemprop ensemble {i+1}/{ENSEMBLE_SIZE} | device={trainer.accelerator.__class__.__name__} | trained {n_epochs_trained}/{max_epochs} epochs | key={safe_key or 'no-cache'}")
+        logger.info(
+            f"Chemprop ensemble {i + 1}/{ENSEMBLE_SIZE} | device={trainer.accelerator.__class__.__name__} | trained {n_epochs_trained}/{max_epochs} epochs | key={safe_key or 'no-cache'}"
+        )
 
         if checkpoint_dir and safe_key:
             checkpoint_dir = Path(checkpoint_dir)
@@ -144,15 +151,21 @@ def train_chemprop(
             config_file = checkpoint_dir / "training_config.json"
             if not config_file.exists():
                 import json
-                config_file.write_text(json.dumps({
-                    "max_epochs": max_epochs,
-                    "val_fraction": val_fraction,
-                    "seed": seed,
-                    "n_ensemble": ENSEMBLE_SIZE,
-                    "architecture": "D-MPNN (BondMessagePassing + MeanAggregation + RegressionFFN)",
-                    "hidden_dim": 300,
-                    "depth": 3,
-                }, indent=2))
+
+                config_file.write_text(
+                    json.dumps(
+                        {
+                            "max_epochs": max_epochs,
+                            "val_fraction": val_fraction,
+                            "seed": seed,
+                            "n_ensemble": ENSEMBLE_SIZE,
+                            "architecture": "D-MPNN (BondMessagePassing + MeanAggregation + RegressionFFN)",
+                            "hidden_dim": 300,
+                            "depth": 3,
+                        },
+                        indent=2,
+                    )
+                )
 
         with torch.inference_mode():
             preds_batched = trainer.predict(mpnn, test_loader)

--- a/src/polaris_generalization/chemprop_utils.py
+++ b/src/polaris_generalization/chemprop_utils.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 # Default training duration. Chemprop's own default is 50; increase for longer runs.
 DEFAULT_MAX_EPOCHS = 50
+ENSEMBLE_SIZE = 3
 
 
 def train_chemprop(
@@ -19,8 +20,9 @@ def train_chemprop(
     seed: int = 42,
     cache_dir: Path | None = None,
     cache_key: str | None = None,
+    checkpoint_dir: Path | None = None,
 ) -> np.ndarray:
-    """Train a D-MPNN regression model and return predictions on test SMILES.
+    """Train an ensemble of D-MPNN regression models and return averaged predictions on test SMILES.
 
     Parameters
     ----------
@@ -28,10 +30,11 @@ def train_chemprop(
     train_y : target values shape (n_train,), already log-transformed if applicable
     test_smiles : protonated SMILES to predict on
     max_epochs : training epochs (default DEFAULT_MAX_EPOCHS)
-    val_fraction : fraction of train carved out as validation (for LR scheduler)
-    seed : controls val split and model weight initialization
+    val_fraction : fraction of train carved out as validation (for early stopping)
+    seed : base seed; each ensemble member uses seed+i for val split and weight init
     cache_dir : directory for caching predictions as .npy files
     cache_key : unique key for this job, e.g. "2.08_LogD_baseline"
+    checkpoint_dir : if set, saves {cache_key}_e{i}.ckpt here after training
 
     Returns
     -------
@@ -44,6 +47,7 @@ def train_chemprop(
     safe_key = None
     if cache_dir and cache_key:
         safe_key = cache_key.replace(">", "_").replace("<", "_").replace(" ", "_")
+        safe_key = f"{safe_key}_e{ENSEMBLE_SIZE}"
         cache_file = Path(cache_dir) / f"{safe_key}.npy"
         if cache_file.exists():
             logger.debug(f"Chemprop cache hit: {cache_file.name}")
@@ -60,60 +64,104 @@ def train_chemprop(
     logging.getLogger("lightning.pytorch").setLevel(logging.WARNING)
     logging.getLogger("lightning").setLevel(logging.WARNING)
 
-    pl.seed_everything(seed, workers=True)
-
-    # Deterministic val split — same indices every run for same seed
-    rng = np.random.default_rng(seed)
-    n_total = len(train_smiles)
-    n_val = max(1, int(val_fraction * n_total))
-    val_idx = rng.choice(n_total, size=n_val, replace=False)
-    train_idx = np.setdiff1d(np.arange(n_total), val_idx)
-
-    # Build datapoints — y must be a sequence for MoleculeDatapoint
-    all_pts = [
-        data.MoleculeDatapoint.from_smi(smi, [float(y)])
-        for smi, y in zip(train_smiles, train_y)
-    ]
-    train_pts = [all_pts[i] for i in train_idx]
-    val_pts = [all_pts[i] for i in val_idx]
-    test_pts = [data.MoleculeDatapoint.from_smi(smi) for smi in test_smiles]
+    from lightning.pytorch.callbacks import EarlyStopping
 
     featurizer = featurizers.SimpleMoleculeMolGraphFeaturizer()
-    train_dset = data.MoleculeDataset(train_pts, featurizer)
-    val_dset = data.MoleculeDataset(val_pts, featurizer)
-    test_dset = data.MoleculeDataset(test_pts, featurizer)
+    test_pts = [data.MoleculeDatapoint.from_smi(smi) for smi in test_smiles]
 
-    # Normalize targets; bake inverse into model so predictions arrive in original scale
-    scaler = train_dset.normalize_targets()
-    val_dset.normalize_targets(scaler)
+    # Track best weights in memory so we can restore after early stopping
+    class _BestWeights(pl.Callback):
+        def __init__(self):
+            self.best_val_loss = float("inf")
+            self.best_state: dict | None = None
 
-    output_transform = chemprop_nn.UnscaleTransform.from_standard_scaler(scaler)
-    mp = chemprop_nn.BondMessagePassing()
-    agg = chemprop_nn.MeanAggregation()
-    ffn = chemprop_nn.RegressionFFN(n_tasks=1, output_transform=output_transform)
-    mpnn = models.MPNN(mp, agg, ffn)
+        def on_validation_end(self, trainer, pl_module):
+            val_loss = trainer.callback_metrics.get("val_loss")
+            if val_loss is not None and float(val_loss) < self.best_val_loss:
+                self.best_val_loss = float(val_loss)
+                self.best_state = {k: v.clone() for k, v in pl_module.state_dict().items()}
 
-    train_loader = data.build_dataloader(train_dset, num_workers=0)
-    val_loader = data.build_dataloader(val_dset, shuffle=False, num_workers=0)
-    test_loader = data.build_dataloader(test_dset, shuffle=False, num_workers=0)
+        def on_fit_end(self, trainer, pl_module):
+            if self.best_state is not None:
+                pl_module.load_state_dict(self.best_state)
 
-    trainer = pl.Trainer(
-        logger=False,
-        enable_checkpointing=False,
-        enable_progress_bar=False,
-        enable_model_summary=False,
-        accelerator="auto",
-        devices=[0],
-        max_epochs=max_epochs,
-    )
-    trainer.fit(mpnn, train_loader, val_loader)
-    logger.info(f"Chemprop trained | device={trainer.accelerator.__class__.__name__} | epochs={max_epochs} | key={safe_key or 'no-cache'}")
+    ensemble_preds = []
+    for i in range(ENSEMBLE_SIZE):
+        member_seed = seed + i
+        pl.seed_everything(member_seed, workers=True)
 
-    with torch.inference_mode():
-        preds_batched = trainer.predict(mpnn, test_loader)
+        rng = np.random.default_rng(member_seed)
+        n_total = len(train_smiles)
+        n_val = max(1, int(val_fraction * n_total))
+        val_idx = rng.choice(n_total, size=n_val, replace=False)
+        train_idx = np.setdiff1d(np.arange(n_total), val_idx)
 
-    # preds_batched: list of tensors shape (batch, 1) → flatten to (n_test,)
-    preds = np.concatenate([p.numpy() for p in preds_batched], axis=0).squeeze(-1)
+        all_pts = [
+            data.MoleculeDatapoint.from_smi(smi, [float(y)])
+            for smi, y in zip(train_smiles, train_y)
+        ]
+        train_pts = [all_pts[j] for j in train_idx]
+        val_pts = [all_pts[j] for j in val_idx]
+
+        train_dset = data.MoleculeDataset(train_pts, featurizer)
+        val_dset = data.MoleculeDataset(val_pts, featurizer)
+        test_dset = data.MoleculeDataset(test_pts, featurizer)
+
+        scaler = train_dset.normalize_targets()
+        val_dset.normalize_targets(scaler)
+
+        output_transform = chemprop_nn.UnscaleTransform.from_standard_scaler(scaler)
+        mp = chemprop_nn.BondMessagePassing()
+        agg = chemprop_nn.MeanAggregation()
+        ffn = chemprop_nn.RegressionFFN(n_tasks=1, output_transform=output_transform)
+        mpnn = models.MPNN(mp, agg, ffn)
+
+        train_loader = data.build_dataloader(train_dset, num_workers=4)
+        val_loader = data.build_dataloader(val_dset, shuffle=False, num_workers=4)
+        test_loader = data.build_dataloader(test_dset, shuffle=False, num_workers=4)
+
+        best_weights = _BestWeights()
+        early_stop = EarlyStopping(monitor="val_loss", patience=10, mode="min")
+
+        trainer = pl.Trainer(
+            logger=False,
+            enable_checkpointing=False,
+            enable_progress_bar=True,
+            enable_model_summary=False,
+            accelerator="auto",
+            devices=[0],
+            max_epochs=max_epochs,
+            callbacks=[early_stop, best_weights],
+        )
+        trainer.fit(mpnn, train_loader, val_loader)
+        n_epochs_trained = min(trainer.current_epoch + 1, max_epochs)
+        logger.info(f"Chemprop ensemble {i+1}/{ENSEMBLE_SIZE} | device={trainer.accelerator.__class__.__name__} | trained {n_epochs_trained}/{max_epochs} epochs | key={safe_key or 'no-cache'}")
+
+        if checkpoint_dir and safe_key:
+            checkpoint_dir = Path(checkpoint_dir)
+            checkpoint_dir.mkdir(parents=True, exist_ok=True)
+            trainer.save_checkpoint(checkpoint_dir / f"{safe_key}_e{i}.ckpt")
+            config_file = checkpoint_dir / "training_config.json"
+            if not config_file.exists():
+                import json
+                config_file.write_text(json.dumps({
+                    "max_epochs": max_epochs,
+                    "val_fraction": val_fraction,
+                    "seed": seed,
+                    "n_ensemble": ENSEMBLE_SIZE,
+                    "architecture": "D-MPNN (BondMessagePassing + MeanAggregation + RegressionFFN)",
+                    "hidden_dim": 300,
+                    "depth": 3,
+                }, indent=2))
+
+        with torch.inference_mode():
+            preds_batched = trainer.predict(mpnn, test_loader)
+
+        member_preds = np.concatenate([p.numpy() for p in preds_batched], axis=0).squeeze(-1)
+        ensemble_preds.append(member_preds)
+
+    # Average predictions across ensemble members
+    preds = np.mean(ensemble_preds, axis=0)
 
     if cache_dir and safe_key:
         cache_file = Path(cache_dir) / f"{safe_key}.npy"

--- a/src/polaris_generalization/chemprop_utils.py
+++ b/src/polaris_generalization/chemprop_utils.py
@@ -1,0 +1,123 @@
+"""Shared Chemprop D-MPNN training utility for single-task regression."""
+
+import os
+from pathlib import Path
+
+import numpy as np
+from loguru import logger
+
+# Default training duration. Chemprop's own default is 50; increase for longer runs.
+DEFAULT_MAX_EPOCHS = 50
+
+
+def train_chemprop(
+    train_smiles: list[str],
+    train_y: np.ndarray,
+    test_smiles: list[str],
+    max_epochs: int = DEFAULT_MAX_EPOCHS,
+    val_fraction: float = 0.1,
+    seed: int = 42,
+    cache_dir: Path | None = None,
+    cache_key: str | None = None,
+) -> np.ndarray:
+    """Train a D-MPNN regression model and return predictions on test SMILES.
+
+    Parameters
+    ----------
+    train_smiles : protonated SMILES for training molecules
+    train_y : target values shape (n_train,), already log-transformed if applicable
+    test_smiles : protonated SMILES to predict on
+    max_epochs : training epochs (default DEFAULT_MAX_EPOCHS)
+    val_fraction : fraction of train carved out as validation (for LR scheduler)
+    seed : controls val split and model weight initialization
+    cache_dir : directory for caching predictions as .npy files
+    cache_key : unique key for this job, e.g. "2.08_LogD_baseline"
+
+    Returns
+    -------
+    np.ndarray of shape (n_test,) in the same scale as train_y
+    """
+    env_cache = os.environ.get("CHEMPROP_CACHE_DIR")
+    if env_cache is not None:
+        cache_dir = Path(env_cache)
+
+    safe_key = None
+    if cache_dir and cache_key:
+        safe_key = cache_key.replace(">", "_").replace("<", "_").replace(" ", "_")
+        cache_file = Path(cache_dir) / f"{safe_key}.npy"
+        if cache_file.exists():
+            logger.debug(f"Chemprop cache hit: {cache_file.name}")
+            return np.load(cache_file)
+
+    # Lazy imports — avoids loading PyTorch when loading cached results
+    import logging
+
+    import torch
+    from chemprop import data, featurizers, models
+    from chemprop import nn as chemprop_nn
+    from lightning import pytorch as pl
+
+    logging.getLogger("lightning.pytorch").setLevel(logging.WARNING)
+    logging.getLogger("lightning").setLevel(logging.WARNING)
+
+    pl.seed_everything(seed, workers=True)
+
+    # Deterministic val split — same indices every run for same seed
+    rng = np.random.default_rng(seed)
+    n_total = len(train_smiles)
+    n_val = max(1, int(val_fraction * n_total))
+    val_idx = rng.choice(n_total, size=n_val, replace=False)
+    train_idx = np.setdiff1d(np.arange(n_total), val_idx)
+
+    # Build datapoints — y must be a sequence for MoleculeDatapoint
+    all_pts = [
+        data.MoleculeDatapoint.from_smi(smi, [float(y)])
+        for smi, y in zip(train_smiles, train_y)
+    ]
+    train_pts = [all_pts[i] for i in train_idx]
+    val_pts = [all_pts[i] for i in val_idx]
+    test_pts = [data.MoleculeDatapoint.from_smi(smi) for smi in test_smiles]
+
+    featurizer = featurizers.SimpleMoleculeMolGraphFeaturizer()
+    train_dset = data.MoleculeDataset(train_pts, featurizer)
+    val_dset = data.MoleculeDataset(val_pts, featurizer)
+    test_dset = data.MoleculeDataset(test_pts, featurizer)
+
+    # Normalize targets; bake inverse into model so predictions arrive in original scale
+    scaler = train_dset.normalize_targets()
+    val_dset.normalize_targets(scaler)
+
+    output_transform = chemprop_nn.UnscaleTransform.from_standard_scaler(scaler)
+    mp = chemprop_nn.BondMessagePassing()
+    agg = chemprop_nn.MeanAggregation()
+    ffn = chemprop_nn.RegressionFFN(n_tasks=1, output_transform=output_transform)
+    mpnn = models.MPNN(mp, agg, ffn)
+
+    train_loader = data.build_dataloader(train_dset, num_workers=0)
+    val_loader = data.build_dataloader(val_dset, shuffle=False, num_workers=0)
+    test_loader = data.build_dataloader(test_dset, shuffle=False, num_workers=0)
+
+    trainer = pl.Trainer(
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        accelerator="auto",
+        devices=[0],
+        max_epochs=max_epochs,
+    )
+    trainer.fit(mpnn, train_loader, val_loader)
+    logger.info(f"Chemprop trained | device={trainer.accelerator.__class__.__name__} | epochs={max_epochs} | key={safe_key or 'no-cache'}")
+
+    with torch.inference_mode():
+        preds_batched = trainer.predict(mpnn, test_loader)
+
+    # preds_batched: list of tensors shape (batch, 1) → flatten to (n_test,)
+    preds = np.concatenate([p.numpy() for p in preds_batched], axis=0).squeeze(-1)
+
+    if cache_dir and safe_key:
+        cache_file = Path(cache_dir) / f"{safe_key}.npy"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        np.save(cache_file, preds)
+
+    return preds

--- a/src/polaris_generalization/visualization.py
+++ b/src/polaris_generalization/visualization.py
@@ -1,12 +1,79 @@
 """Shared visualization utilities for the Polaris project."""
 
+from pathlib import Path
+
 import matplotlib.pyplot as plt
+import numpy as np
 import seaborn as sns
 
 DEFAULT_DPI = 150
+
+MODEL_COLORS = {"xgboost": "steelblue", "chemprop": "darkorange"}
+MODEL_LABELS = {"xgboost": "XGBoost", "chemprop": "Chemprop (D-MPNN)"}
 
 
 def set_style():
     """Set default plotting style."""
     sns.set_theme(style="whitegrid", context="paper", font_scale=1.2)
     plt.rcParams["figure.dpi"] = DEFAULT_DPI
+
+
+def plot_model_comparison_bars(
+    data_by_model: dict,
+    endpoint_col: str,
+    metric_col: str,
+    ylabel: str,
+    title: str,
+    output_path: Path,
+    dpi: int = DEFAULT_DPI,
+) -> None:
+    """Grouped bar chart comparing two or more models per endpoint.
+
+    Parameters
+    ----------
+    data_by_model : {"xgboost": df, "chemprop": df} where each df has endpoint_col and metric_col
+    endpoint_col : column name for x-axis grouping (e.g. "endpoint")
+    metric_col : column name for bar height (e.g. "r2")
+    ylabel, title : axis labels
+    output_path : where to save the figure
+    """
+    import pandas as pd
+
+    model_names = list(data_by_model.keys())
+    first_df = next(iter(data_by_model.values()))
+    endpoints = sorted(first_df[endpoint_col].unique())
+    n_ep = len(endpoints)
+    n_models = len(model_names)
+
+    fig, ax = plt.subplots(figsize=(max(10, n_ep * 1.6), 5))
+    x = np.arange(n_ep)
+    width = 0.8 / n_models
+
+    for i, model_name in enumerate(model_names):
+        df = data_by_model[model_name]
+        means, stds = [], []
+        for ep in endpoints:
+            ep_vals = df[df[endpoint_col] == ep][metric_col].dropna()
+            means.append(ep_vals.mean() if len(ep_vals) else np.nan)
+            stds.append(ep_vals.std() if len(ep_vals) > 1 else 0.0)
+
+        offset = (i - n_models / 2 + 0.5) * width
+        yerr = stds if any(s > 0 for s in stds) else None
+        ax.bar(
+            x + offset, means, width,
+            yerr=yerr,
+            label=MODEL_LABELS.get(model_name, model_name),
+            color=MODEL_COLORS.get(model_name, f"C{i}"),
+            edgecolor="white",
+            alpha=0.85,
+            capsize=3,
+        )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(endpoints, rotation=45, ha="right", fontsize=8)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=dpi, bbox_inches="tight")
+    plt.close("all")

--- a/src/polaris_generalization/visualization.py
+++ b/src/polaris_generalization/visualization.py
@@ -37,8 +37,6 @@ def plot_model_comparison_bars(
     ylabel, title : axis labels
     output_path : where to save the figure
     """
-    import pandas as pd
-
     model_names = list(data_by_model.keys())
     first_df = next(iter(data_by_model.values()))
     endpoints = sorted(first_df[endpoint_col].unique())
@@ -60,7 +58,9 @@ def plot_model_comparison_bars(
         offset = (i - n_models / 2 + 0.5) * width
         yerr = stds if any(s > 0 for s in stds) else None
         ax.bar(
-            x + offset, means, width,
+            x + offset,
+            means,
+            width,
             yerr=yerr,
             label=MODEL_LABELS.get(model_name, model_name),
             color=MODEL_COLORS.get(model_name, f"C{i}"),


### PR DESCRIPTION
This PR basically adds a ⁠` --model` ⁠ flag for running all the notebooks which involve model training.
The ⁠ `--model` ⁠ can be ⁠` xgboost` ⁠ or `chemprop` ⁠ or ⁠ `combined ⁠`
The first two train respective models and make the respective figures. You can run ⁠`--model combined` ⁠ which trains both models (or caches the predictions for both of them and makes combined figures..

Ideally, one should run ⁠ `--model xgboost `⁠ then ⁠ `--model chemprop` ⁠ to get all relevant figures and then run ⁠` --model` combined ⁠ to get the overlaying figures.

You can modify the plotting/figures code once all teh training is done and I am able to share the new/final ⁠ data ⁠ directory which will have all the trained chemprop models and their predictions that you can re-run the notebooks in seconds.