### PR TITLE
Adding the CheMeleon foundation model instead of out-of-the-box chemprop models

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ pixi run python
 
 # Run an analysis notebook (cheminformatics env required for RDKit, Chemprop, PyArrow)
 pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py
-pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --model chemprop
+pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --model chemeleon
 pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --combined
 ```
 
@@ -52,27 +52,27 @@ This is a generalization evaluation framework for molecular ML, analyzing how mo
    - `config.py`: Centralized path definitions using pathlib
    - `visualization.py`: Plotting utilities — `set_style()`, `DEFAULT_DPI`, `MODEL_COLORS`, `MODEL_LABELS`, `plot_model_comparison_bars()`
    - `tuning.py`: Optuna TPE XGBoost hyperparameter tuning with JSON caching (`tune_xgboost`)
-   - `chemprop_utils.py`: Chemprop D-MPNN training with prediction caching (`train_chemprop`)
+   - `chemprop_utils.py`: CheMeleon fine-tuning and Chemprop D-MPNN training with prediction caching (`train_chemeleon`, `train_chemprop`)
 
 2. **Notebooks** (`notebooks/`): Analysis notebooks following phase-based naming
    - Convention: `<phase>.<sequence>-<initials>-<description>.py`
    - Phases: 0 = exploration, 1 = data loading, 2 = analysis, 3 = figures
-   - All modeling notebooks support `--model xgboost|chemprop` and `--combined` flags
+   - All modeling notebooks support `--model xgboost|chemeleon` and `--combined` flags (2.12 still uses `chemprop`)
 
 3. **Data Organization** (cookiecutter data science):
    - `data/external/`: External datasets
    - `data/raw/`: Original immutable data
-   - `data/interim/`: Intermediate data — CV folds, Tanimoto matrix, `optuna_cache/`, `chemprop_pred_cache/`
+   - `data/interim/`: Intermediate data — CV folds, Tanimoto matrix, `optuna_cache/`
    - `data/processed/`: Analysis outputs, organized as `{notebook}/{model}/` with a `combined/` subdirectory
 
 4. **Configuration** (`configs/`): Model and experiment configuration files
 
-### Modeling: XGBoost vs Chemprop
+### Modeling: XGBoost vs CheMeleon
 
 Every modeling notebook (2.07–2.15) supports two model backends:
 
 - **XGBoost** (`--model xgboost`, default): ECFP4 (2048-bit) + ~200 RDKit 2D descriptors, Optuna TPE-tuned per endpoint. Hyperparameters cached as JSON in `data/interim/optuna_cache/`.
-- **Chemprop** (`--model chemprop`): D-MPNN trained directly on protonated SMILES, default hyperparameters (hidden_dim=300, depth=3, 50 epochs). Predictions cached as `.npy` in `data/interim/chemprop_pred_cache/`.
+- **CheMeleon** (`--model chemeleon`): Pre-trained BondMessagePassing foundation model fine-tuned per endpoint. Weights stored at `data/interim/chemeleon_mp.pt`; auto-downloaded from Zenodo (record 15460715, `https://zenodo.org/records/15460715/files/chemeleon_mp.pt`) on first call by `train_chemeleon`. FFN: 2 layers × 1024 hidden. Predictions cached as `.npy` in `data/processed/{notebook}/chemeleon/pred_cache/`.
 
 Both models use dimorphite_dl protonation at assay-relevant pH before training. Log-transform protocol (`log10(clip(x, 1e-10) + 1)`) applies to all endpoints except LogD for both models.
 

--- a/notebooks/2.07-seal-performance-distance.py
+++ b/notebooks/2.07-seal-performance-distance.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Performance-over-distance curves for all endpoints across all split strategies.
 
-Trains a model (XGBoost or Chemprop D-MPNN) on pre-saved CV folds (cluster, time,
+Trains a model (XGBoost or CheMeleon) on pre-saved CV folds (cluster, time,
 target — repeat 0), then plots how RMSE degrades with distance from training data.
 Molecules are protonated at assay-relevant pH using dimorphite_dl before feature
 computation. For endpoints not already on log scale (everything except LogD),
@@ -10,7 +10,7 @@ OpenADMET competition protocol.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.07-seal-performance-distance.py
-    pixi run -e cheminformatics python notebooks/2.07-seal-performance-distance.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.07-seal-performance-distance.py --model chemeleon
     pixi run -e cheminformatics python notebooks/2.07-seal-performance-distance.py --combined
 
 Outputs (under data/processed/2.07-seal-performance-distance/{model}/):
@@ -45,7 +45,7 @@ from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -426,12 +426,12 @@ def _generate_figures(
 
 
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
-    """Overlay XGBoost (solid) and Chemprop (dashed) distance curves on same axes."""
+    """Overlay XGBoost (solid) and CheMeleon (dashed) distance curves on same axes."""
     combined_dir = output_dir / "combined"
     combined_dir.mkdir(parents=True, exist_ok=True)
 
     model_preds = {}
-    for model in ["xgboost", "chemprop"]:
+    for model in ["xgboost", "chemeleon"]:
         pred_file = output_dir / model / "predictions.parquet"
         if not pred_file.exists():
             logger.warning(f"Missing {pred_file}; skipping combined figures")
@@ -439,7 +439,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
         model_preds[model] = pd.read_parquet(pred_file)
 
     strat_colors = {"cluster": "steelblue", "time": "coral", "target": "forestgreen"}
-    model_linestyles = {"xgboost": "-", "chemprop": "--"}
+    model_linestyles = {"xgboost": "-", "chemeleon": "--"}
     active_endpoints = sorted(model_preds["xgboost"]["endpoint"].unique())
     n_ep = len(active_endpoints)
     ncols = 2
@@ -496,7 +496,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
 
     # ── Degradation-ratio comparison bar chart ───────────────────────────
     model_metrics = {}
-    for model in ["xgboost", "chemprop"]:
+    for model in ["xgboost", "chemeleon"]:
         summary_file = output_dir / model / "performance_distance_summary.csv"
         if summary_file.exists():
             model_metrics[model] = pd.read_csv(summary_file)
@@ -507,7 +507,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
             endpoint_col="endpoint",
             metric_col="degradation_ratio",
             ylabel="Degradation ratio (farthest / closest bin RMSE)",
-            title="Structural-distance degradation ratio: XGBoost vs Chemprop",
+            title="Structural-distance degradation ratio: XGBoost vs CheMeleon",
             output_path=combined_dir / "degradation_ratio_comparison.png",
             dpi=dpi,
         )
@@ -527,8 +527,8 @@ def main(
         PROCESSED_DATA_DIR / "2.07-seal-performance-distance", help="Output directory"
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
-    model: str = typer.Option("xgboost", help="Model backend: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop figures"),
+    model: str = typer.Option("xgboost", help="Model backend: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -543,13 +543,37 @@ def main(
     model_dir.mkdir(parents=True, exist_ok=True)
 
     # Skip if already complete
-    if (model_dir / "predictions.parquet").exists() and (model_dir / "performance_distance_summary.csv").exists():
+    if (model_dir / "predictions.parquet").exists():
         logger.info(f"Found existing outputs for {model}, skipping training")
         pred_df = pd.read_parquet(model_dir / "predictions.parquet")
-        perf_df = pd.read_csv(model_dir / "per_fold_performance.csv")
         all_results = []
-        for _, row in pred_df.iterrows():
-            pass
+        for (ep, strat, fold_id), grp in pred_df.groupby(["endpoint", "strategy", "fold"]):
+            y_test = grp["y_true"].values
+            y_pred_vals = grp["y_pred"].values
+            sq_errors = (y_pred_vals - y_test) ** 2
+            mae = mean_absolute_error(y_test, y_pred_vals)
+            r2 = r2_score(y_test, y_pred_vals)
+            sp_r, _ = spearmanr(y_test, y_pred_vals)
+            kt, _ = kendalltau(y_test, y_pred_vals)
+            baseline_mad = np.mean(np.abs(y_test - np.mean(y_test)))
+            rae = mae / baseline_mad if baseline_mad > 0 else np.nan
+            all_results.append({
+                "endpoint": ep, "strategy": strat, "fold": fold_id,
+                "n_train": 0, "n_test": len(grp),
+                "struct_dist": grp["struct_1nn"].values,
+                "target_dist": grp["target_1nn"].values,
+                "sq_errors": sq_errors,
+                "mae": mae, "r2": r2, "spearman_r": sp_r,
+                "kendall_tau": kt, "rae": rae,
+                "overall_rmse": float(np.sqrt(sq_errors.mean())),
+            })
+        perf_df = pd.DataFrame([
+            {"endpoint": r["endpoint"], "strategy": r["strategy"], "fold": r["fold"],
+             "n_train": r["n_train"], "n_test": r["n_test"], "mae": r["mae"],
+             "r2": r["r2"], "spearman_r": r["spearman_r"], "kendall_tau": r["kendall_tau"],
+             "rae": r["rae"], "rmse": r["overall_rmse"]}
+            for r in all_results
+        ])
         _generate_figures(all_results, perf_df, pred_df, model_dir, model, dpi)
         return
 
@@ -598,7 +622,7 @@ def main(
     )
     pbar = tqdm(total=total_iters, desc=f"Training {model}", unit="fold")
 
-    chemprop_cache_dir = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    pred_cache_dir = model_dir / "pred_cache"
 
     for ep in ENDPOINTS:
         mask = df[ep].notna().values
@@ -651,11 +675,10 @@ def main(
                 else:
                     train_smiles = [ep_prot_smiles[i] for i in train_idx]
                     test_smiles = [ep_prot_smiles[i] for i in test_idx]
-                    y_pred = train_chemprop(
+                    y_pred = train_chemeleon(
                         train_smiles, y_train, test_smiles,
-                        cache_dir=chemprop_cache_dir,
-                        cache_key=f"2.07_{ep}_{strat_name}_fold{fold_id}",
-                        checkpoint_dir=model_dir / "models",
+                        cache_dir=pred_cache_dir,
+                        cache_key=f"2.07_{ep}_{strat_name}_fold{fold_id}"
                     )
 
                 sq_errors = (y_pred - y_test) ** 2

--- a/notebooks/2.08-seal-baseline-performance.py
+++ b/notebooks/2.08-seal-baseline-performance.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 """Baseline model performance on the original train/test split.
 
-Trains XGBoost or Chemprop D-MPNN on the competition split (5,326 / 2,282).
+Trains XGBoost or CheMeleon on the competition split (5,326 / 2,282).
 Molecules are protonated at the relevant assay pH using dimorphite_dl:
   - pH 7.4: LogD, KSOL, HLM/MLM CLint, MPPB, MBPB, MGMB
   - pH 6.5: Caco-2 Papp A>B, Caco-2 Efflux (apical compartment)
 
 XGBoost uses ECFP4 + full RDKit 2D descriptors (~200), Optuna TPE-tuned per endpoint.
-Chemprop D-MPNN uses default hyperparameters (hidden_dim=300, depth=3, 50 epochs).
+CheMeleon fine-tunes the pre-trained foundation model (FFN: 2 layers × 1024 hidden).
 
 For endpoints not on log scale (everything except LogD), targets are log-transformed
 via log10(clip(x, 1e-10) + 1), matching the OpenADMET competition protocol.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py
-    pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --model chemeleon
     pixi run -e cheminformatics python notebooks/2.08-seal-baseline-performance.py --combined
 
 Outputs (per model):
@@ -46,7 +46,7 @@ from scipy.stats import kendalltau, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -271,9 +271,9 @@ def _generate_figures(
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' metrics and produce side-by-side comparison figures."""
     xgb_path = output_dir / "xgboost" / "overall_metrics.csv"
-    chemprop_path = output_dir / "chemprop" / "overall_metrics.csv"
+    chemeleon_path = output_dir / "chemeleon" / "overall_metrics.csv"
 
-    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemeleon", chemeleon_path)] if not p.exists()]
     if missing:
         logger.error(f"Missing results for: {missing}. Run those models first.")
         return
@@ -282,7 +282,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     combined_dir.mkdir(parents=True, exist_ok=True)
 
     xgb = pd.read_csv(xgb_path)
-    chemprop = pd.read_csv(chemprop_path)
+    chemeleon = pd.read_csv(chemeleon_path)
 
     # Comparison CSV
     merge_cols = ["endpoint", "mae", "r2", "spearman_r", "rae", "kendall_tau"]
@@ -290,7 +290,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
         xgb[merge_cols]
         .rename(columns={c: f"{c}_xgboost" for c in merge_cols if c != "endpoint"})
         .merge(
-            chemprop[merge_cols].rename(columns={c: f"{c}_chemprop" for c in merge_cols if c != "endpoint"}),
+            chemeleon[merge_cols].rename(columns={c: f"{c}_chemeleon" for c in merge_cols if c != "endpoint"}),
             on="endpoint",
         )
     )
@@ -298,7 +298,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     logger.info("Saved metrics_comparison.csv")
 
     # Grouped bar charts
-    data_by_model = {"xgboost": xgb, "chemprop": chemprop}
+    data_by_model = {"xgboost": xgb, "chemeleon": chemeleon}
     for metric, ylabel, fname in [
         ("r2", "R²", "r2_comparison"),
         ("mae", "MAE", "mae_comparison"),
@@ -310,7 +310,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
             "endpoint",
             metric,
             ylabel,
-            f"{ylabel} — XGBoost vs Chemprop (original split)",
+            f"{ylabel} — XGBoost vs CheMeleon (original split)",
             combined_dir / f"{fname}.png",
             dpi=dpi,
         )
@@ -326,8 +326,8 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
 def main(
     output_dir: Path = typer.Option(PROCESSED_DATA_DIR / "2.08-seal-baseline-performance", help="Output directory"),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
-    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -336,8 +336,8 @@ def main(
         _generate_combined_figures(output_dir, dpi)
         return
 
-    if model not in ("xgboost", "chemprop"):
-        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+    if model not in ("xgboost", "chemeleon"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemeleon.")
         raise typer.Exit(1)
 
     _migrate_flat_outputs(output_dir)
@@ -348,7 +348,7 @@ def main(
     # ── Skip training if predictions already exist ────────────────────
     pred_path = model_dir / "predictions.parquet"
     metrics_path = model_dir / "overall_metrics.csv"
-    if pred_path.exists() and metrics_path.exists():
+    if pred_path.exists():
         logger.info(f"Existing {model} predictions found — regenerating figures only")
         pred_df = pd.read_parquet(pred_path)
         metrics_df = pd.read_csv(metrics_path)
@@ -399,7 +399,7 @@ def main(
 
     # ── 4. Train and evaluate per endpoint ───────────────────────────
     optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
-    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    chemprop_cache = model_dir / "pred_cache"
 
     metric_rows = []
     prediction_rows = []
@@ -434,14 +434,13 @@ def main(
         else:
             train_prot = [s for s, m in zip(prot_by_ph[ph]["train"], train_mask) if m]
             test_prot = [s for s, m in zip(prot_by_ph[ph]["test"], test_mask) if m]
-            logger.info(f"  {ep} ({n_train} train, {n_test} test) — training Chemprop D-MPNN")
-            y_pred = train_chemprop(
+            logger.info(f"  {ep} ({n_train} train, {n_test} test) — fine-tuning CheMeleon")
+            y_pred = train_chemeleon(
                 train_prot,
                 y_tr,
                 test_prot,
                 cache_dir=chemprop_cache,
-                cache_key=f"2.08_{ep}_baseline",
-                checkpoint_dir=model_dir / "models",
+                cache_key=f"2.08_{ep}_baseline"
             )
 
         mae = mean_absolute_error(y_te, y_pred)

--- a/notebooks/2.09-seal-iid-vs-ood-series.py
+++ b/notebooks/2.09-seal-iid-vs-ood-series.py
@@ -3,16 +3,17 @@
 
 Takes two large Butina clusters (chemical series), time-splits the largest
 into train + IID validation, uses the smaller cluster as OOD test set, trains
-XGBoost or Chemprop D-MPNN models, and compares squared error intra-series
+XGBoost or CheMeleon models, and compares squared error intra-series
 (IID) vs inter-series (OOD). Demonstrates that chemical series + time-split
 uniquely enable this analysis.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.09-seal-iid-vs-ood-series.py
-    pixi run -e cheminformatics python notebooks/2.09-seal-iid-vs-ood-series.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.09-seal-iid-vs-ood-series.py --model chemeleon
     pixi run -e cheminformatics python notebooks/2.09-seal-iid-vs-ood-series.py --combined
 
 Outputs (per model):
+    data/processed/2.09-seal-iid-vs-ood-series/{model}/predictions.parquet
     data/processed/2.09-seal-iid-vs-ood-series/{model}/iid_vs_ood_errors.csv
     data/processed/2.09-seal-iid-vs-ood-series/{model}/summary_metrics.csv
     data/processed/2.09-seal-iid-vs-ood-series/{model}/squared_error_distributions.png
@@ -45,7 +46,7 @@ from scipy.stats import kendalltau, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -309,9 +310,9 @@ def _generate_figures(errors_df: pd.DataFrame, metrics_df: pd.DataFrame,
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' metrics and produce side-by-side comparison figures."""
     xgb_path = output_dir / "xgboost" / "summary_metrics.csv"
-    chemprop_path = output_dir / "chemprop" / "summary_metrics.csv"
+    chemeleon_path = output_dir / "chemeleon" / "summary_metrics.csv"
 
-    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemeleon", chemeleon_path)] if not p.exists()]
     if missing:
         logger.error(f"Missing results for: {missing}. Run those models first.")
         return
@@ -320,12 +321,12 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     combined_dir.mkdir(parents=True, exist_ok=True)
 
     xgb = pd.read_csv(xgb_path)
-    chemprop = pd.read_csv(chemprop_path)
+    chemeleon = pd.read_csv(chemeleon_path)
 
     for set_label in ("iid", "ood"):
         xgb_set = xgb[xgb["set"] == set_label].copy()
-        chemprop_set = chemprop[chemprop["set"] == set_label].copy()
-        data_by_model = {"xgboost": xgb_set, "chemprop": chemprop_set}
+        chemeleon_set = chemeleon[chemeleon["set"] == set_label].copy()
+        data_by_model = {"xgboost": xgb_set, "chemeleon": chemeleon_set}
 
         for metric, ylabel, fname in [
             ("mae", "MAE", "mae"),
@@ -335,7 +336,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
         ]:
             plot_model_comparison_bars(
                 data_by_model, "endpoint", metric, ylabel,
-                f"{ylabel} — XGBoost vs Chemprop ({set_label.upper()})",
+                f"{ylabel} — XGBoost vs CheMeleon ({set_label.upper()})",
                 combined_dir / f"{fname}_{set_label}_comparison.png", dpi=dpi,
             )
             logger.info(f"Saved {fname}_{set_label}_comparison.png")
@@ -350,8 +351,8 @@ def main(
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     train_frac: float = typer.Option(0.8, help="Fraction of largest cluster for training (rest = IID val)"),
-    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -360,8 +361,8 @@ def main(
         _generate_combined_figures(output_dir, dpi)
         return
 
-    if model not in ("xgboost", "chemprop"):
-        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+    if model not in ("xgboost", "chemeleon"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemeleon.")
         raise typer.Exit(1)
 
     _migrate_flat_outputs(output_dir)
@@ -370,11 +371,12 @@ def main(
     model_dir.mkdir(parents=True, exist_ok=True)
 
     # Skip training if outputs already exist
+    pred_path = model_dir / "predictions.parquet"
     errors_path = model_dir / "iid_vs_ood_errors.csv"
     metrics_path = model_dir / "summary_metrics.csv"
-    if errors_path.exists() and metrics_path.exists():
-        logger.info(f"Existing {model} outputs found — regenerating figures only")
-        errors_df = pd.read_csv(errors_path)
+    if pred_path.exists():
+        logger.info(f"Existing {model} predictions found — regenerating figures only")
+        errors_df = pd.read_parquet(pred_path)
         metrics_df = pd.read_csv(metrics_path)
         _generate_figures(errors_df, metrics_df, model_dir, dpi)
         logger.info("Figures regenerated (no models retrained)")
@@ -506,7 +508,7 @@ def main(
     metric_rows = []
 
     optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
-    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    chemprop_cache = model_dir / "pred_cache"
 
     for ep in ENDPOINTS:
         ph = ENDPOINT_PH[ep]
@@ -560,18 +562,15 @@ def main(
             iid_prot = [all_iid_prot[i] for i in np.where(iid_mask)[0]]
             ood_prot = [all_ood_prot[i] for i in np.where(ood_mask)[0]]
 
-            y_pred_iid = train_chemprop(
-                train_prot, y_tr, iid_prot,
+            # Train once, predict on concatenated IID+OOD test set, then split.
+            combined_prot = iid_prot + ood_prot
+            combined_preds = train_chemeleon(
+                train_prot, y_tr, combined_prot,
                 cache_dir=chemprop_cache,
-                cache_key=f"2.09_{ep}_iid_ood_iid",
-                checkpoint_dir=model_dir / "models",
+                cache_key=f"2.09_{ep}_iid_ood"
             )
-            y_pred_ood = train_chemprop(
-                train_prot, y_tr, ood_prot,
-                cache_dir=chemprop_cache,
-                cache_key=f"2.09_{ep}_iid_ood_ood",
-                checkpoint_dir=model_dir / "models",
-            )
+            y_pred_iid = combined_preds[:len(iid_prot)]
+            y_pred_ood = combined_preds[len(iid_prot):]
 
         se_iid = (y_iid - y_pred_iid) ** 2
         se_ood = (y_ood - y_pred_ood) ** 2
@@ -579,10 +578,12 @@ def main(
         iid_names = iid_df["Molecule Name"].values[iid_mask]
         ood_names = ood_df["Molecule Name"].values[ood_mask]
 
-        for name, se in zip(iid_names, se_iid):
-            error_rows.append({"Molecule Name": name, "endpoint": ep, "set": "iid", "squared_error": se})
-        for name, se in zip(ood_names, se_ood):
-            error_rows.append({"Molecule Name": name, "endpoint": ep, "set": "ood", "squared_error": se})
+        for name, y_true_val, y_pred_val, se in zip(iid_names, y_iid, y_pred_iid, se_iid):
+            error_rows.append({"Molecule Name": name, "endpoint": ep, "set": "iid",
+                               "y_true": y_true_val, "y_pred": y_pred_val, "squared_error": se})
+        for name, y_true_val, y_pred_val, se in zip(ood_names, y_ood, y_pred_ood, se_ood):
+            error_rows.append({"Molecule Name": name, "endpoint": ep, "set": "ood",
+                               "y_true": y_true_val, "y_pred": y_pred_val, "squared_error": se})
 
         for label, y_true, y_pred, se in [
             ("iid", y_iid, y_pred_iid, se_iid),
@@ -617,6 +618,8 @@ def main(
     errors_df = pd.DataFrame(error_rows)
     metrics_df = pd.DataFrame(metric_rows)
 
+    errors_df.to_parquet(pred_path, index=False)
+    logger.info(f"Saved predictions.parquet ({len(errors_df)} rows)")
     errors_df.to_csv(errors_path, index=False)
     metrics_df.to_csv(metrics_path, index=False)
     logger.info("Saved iid_vs_ood_errors.csv and summary_metrics.csv")

--- a/notebooks/2.10-seal-activity-cliff-eval.py
+++ b/notebooks/2.10-seal-activity-cliff-eval.py
@@ -2,7 +2,7 @@
 """Activity cliff evaluation (paper Fig S3, ref: MoleculeACE).
 
 Identifies activity cliffs — pairs of structurally similar molecules with large
-activity differences — and evaluates XGBoost or Chemprop D-MPNN performance on
+activity differences — and evaluates XGBoost or CheMeleon performance on
 cliff vs non-cliff molecules. Uses cluster-split CV (repeat 0, 5 folds) to train
 and evaluate. Demonstrates that smoothly interpolating models fail on activity cliffs.
 
@@ -10,15 +10,15 @@ Usage:
     # Full eval (default XGBoost)
     pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py main
 
-    # Full eval with Chemprop D-MPNN
-    pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py main --model chemprop
+    # Full eval with CheMeleon
+    pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py main --model chemeleon
 
-    # Combined XGBoost vs Chemprop comparison figures
+    # Combined XGBoost vs CheMeleon comparison figures
     pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py main --combined
 
     # Threshold-sensitivity sweep using existing model predictions
     pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py sensitivity
-    pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py sensitivity --model chemprop
+    pixi run -e cheminformatics python notebooks/2.10-seal-activity-cliff-eval.py sensitivity --model chemeleon
 
 Model-agnostic outputs:
     data/processed/2.10-seal-activity-cliff-eval/cliff_stats.csv
@@ -26,6 +26,7 @@ Model-agnostic outputs:
     data/processed/2.10-seal-activity-cliff-eval/cliff_characterization.png
 
 Outputs (per model, main):
+    data/processed/2.10-seal-activity-cliff-eval/{model}/predictions.parquet
     data/processed/2.10-seal-activity-cliff-eval/{model}/cliff_vs_noncliff_errors.csv
     data/processed/2.10-seal-activity-cliff-eval/{model}/summary_metrics.csv
     data/processed/2.10-seal-activity-cliff-eval/{model}/squared_error_distributions.png
@@ -62,7 +63,7 @@ from scipy.stats import kendalltau, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -310,9 +311,9 @@ def _generate_figures(errors_df: pd.DataFrame, metrics_df: pd.DataFrame,
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' metrics and produce side-by-side comparison figures."""
     xgb_path = output_dir / "xgboost" / "summary_metrics.csv"
-    chemprop_path = output_dir / "chemprop" / "summary_metrics.csv"
+    chemeleon_path = output_dir / "chemeleon" / "summary_metrics.csv"
 
-    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemeleon", chemeleon_path)] if not p.exists()]
     if missing:
         logger.error(f"Missing results for: {missing}. Run those models first.")
         return
@@ -321,12 +322,12 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     combined_dir.mkdir(parents=True, exist_ok=True)
 
     xgb = pd.read_csv(xgb_path)
-    chemprop = pd.read_csv(chemprop_path)
+    chemeleon = pd.read_csv(chemeleon_path)
 
     for set_label in ("cliff", "non-cliff"):
         xgb_set = xgb[xgb["set"] == set_label].copy()
-        chemprop_set = chemprop[chemprop["set"] == set_label].copy()
-        data_by_model = {"xgboost": xgb_set, "chemprop": chemprop_set}
+        chemeleon_set = chemeleon[chemeleon["set"] == set_label].copy()
+        data_by_model = {"xgboost": xgb_set, "chemeleon": chemeleon_set}
 
         fname_label = set_label.replace("-", "")
         for metric, ylabel, fname in [
@@ -337,7 +338,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
         ]:
             plot_model_comparison_bars(
                 data_by_model, "endpoint", metric, ylabel,
-                f"{ylabel} — XGBoost vs Chemprop ({set_label})",
+                f"{ylabel} — XGBoost vs CheMeleon ({set_label})",
                 combined_dir / f"{fname}_{fname_label}_comparison.png", dpi=dpi,
             )
             logger.info(f"Saved {fname}_{fname_label}_comparison.png")
@@ -353,8 +354,8 @@ def main(
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     sim_threshold: float = typer.Option(0.85, help="Tanimoto similarity threshold for similar pairs"),
     min_diff: float = typer.Option(1.0, help="Absolute activity difference threshold for cliff definition"),
-    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -363,8 +364,8 @@ def main(
         _generate_combined_figures(output_dir, dpi)
         return
 
-    if model not in ("xgboost", "chemprop"):
-        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+    if model not in ("xgboost", "chemeleon"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemeleon.")
         raise typer.Exit(1)
 
     _migrate_flat_outputs(output_dir)
@@ -486,11 +487,12 @@ def main(
     plt.close("all")
 
     # Skip training if outputs already exist
+    pred_path = model_dir / "predictions.parquet"
     errors_path = model_dir / "cliff_vs_noncliff_errors.csv"
     metrics_path = model_dir / "summary_metrics.csv"
-    if errors_path.exists() and metrics_path.exists():
-        logger.info(f"Existing {model} outputs found — regenerating figures only")
-        errors_df = pd.read_csv(errors_path)
+    if pred_path.exists():
+        logger.info(f"Existing {model} predictions found — regenerating figures only")
+        errors_df = pd.read_parquet(pred_path)
         metrics_df = pd.read_csv(metrics_path)
         _generate_figures(errors_df, metrics_df, model_dir, dpi)
         logger.info("Figures regenerated (no models retrained)")
@@ -501,7 +503,7 @@ def main(
     metric_rows = []
 
     optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
-    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    chemprop_cache = model_dir / "pred_cache"
 
     for ep in ENDPOINTS:
         ph = ENDPOINT_PH[ep]
@@ -568,11 +570,10 @@ def main(
             else:
                 train_prot = [all_prot[i] for i in np.where(train_mask)[0]]
                 test_prot = [all_prot[i] for i in np.where(test_mask)[0]]
-                y_pred = train_chemprop(
+                y_pred = train_chemeleon(
                     train_prot, y_tr, test_prot,
                     cache_dir=chemprop_cache,
-                    cache_key=f"2.10_{ep}_cluster_fold{fold_id}",
-                    checkpoint_dir=model_dir / "models",
+                    cache_key=f"2.10_{ep}_cluster_fold{fold_id}"
                 )
 
             se = (y_te - y_pred) ** 2
@@ -590,6 +591,8 @@ def main(
                 })
 
     errors_df = pd.DataFrame(error_rows)
+    errors_df.to_parquet(pred_path, index=False)
+    logger.info(f"Saved predictions.parquet ({len(errors_df)} rows)")
     errors_df.to_csv(errors_path, index=False)
     logger.info(f"Saved cliff_vs_noncliff_errors.csv ({len(errors_df)} rows)")
 
@@ -650,7 +653,7 @@ def sensitivity(
         PROCESSED_DATA_DIR / "2.10-seal-activity-cliff-eval", help="Output directory"
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
-    model: str = typer.Option("xgboost", help="Prediction source: xgboost or chemprop"),
+    model: str = typer.Option("xgboost", help="Prediction source: xgboost or chemeleon"),
     thresholds: str = typer.Option(
         "0.70,0.75,0.80,0.85,0.90,0.95",
         help="Comma-separated Tanimoto similarity thresholds to sweep",
@@ -673,8 +676,8 @@ def sensitivity(
     """
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
-    if model not in ("xgboost", "chemprop"):
-        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+    if model not in ("xgboost", "chemeleon"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemeleon.")
         raise typer.Exit(1)
 
     _migrate_flat_outputs(output_dir)
@@ -691,12 +694,12 @@ def sensitivity(
     dist_mol_names = npz["molecule_names"]
     name_to_dist_idx = {str(n): i for i, n in enumerate(dist_mol_names)}
 
-    errors_path = model_dir / "cliff_vs_noncliff_errors.csv"
-    if not errors_path.exists():
+    pred_path = model_dir / "predictions.parquet"
+    if not pred_path.exists():
         raise FileNotFoundError(
-            f"{errors_path} not found — run `main --model {model}` first to generate predictions"
+            f"{pred_path} not found — run `main --model {model}` first to generate predictions"
         )
-    errors_df = pd.read_csv(errors_path)
+    errors_df = pd.read_parquet(pred_path)
     logger.info(f"Loaded {len(errors_df)} existing {model} test predictions")
 
     rows = []

--- a/notebooks/2.11-seal-scaffold-vs-random.py
+++ b/notebooks/2.11-seal-scaffold-vs-random.py
@@ -7,7 +7,7 @@ to cluster-based splitting (from 2.03) which produces genuine structural separat
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.11-seal-scaffold-vs-random.py
-    pixi run -e cheminformatics python notebooks/2.11-seal-scaffold-vs-random.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.11-seal-scaffold-vs-random.py --model chemeleon
     pixi run -e cheminformatics python notebooks/2.11-seal-scaffold-vs-random.py --combined
 
 Outputs (per model, under data/processed/2.11-seal-scaffold-vs-random/<model>/):
@@ -45,7 +45,7 @@ from scipy.stats import kendalltau, ks_2samp, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -352,15 +352,15 @@ def _save_figures(
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' aggregated_metrics.csv and produce combined comparison figures."""
     xgb_path = output_dir / "xgboost" / "aggregated_metrics.csv"
-    chemprop_path = output_dir / "chemprop" / "aggregated_metrics.csv"
+    chemeleon_path = output_dir / "chemeleon" / "aggregated_metrics.csv"
 
-    missing = [p for p in [xgb_path, chemprop_path] if not p.exists()]
+    missing = [p for p in [xgb_path, chemeleon_path] if not p.exists()]
     if missing:
         logger.error(f"Cannot generate combined figures — missing: {[str(p) for p in missing]}")
         return
 
     xgb_df = pd.read_csv(xgb_path)
-    chemprop_df = pd.read_csv(chemprop_path)
+    chemeleon_df = pd.read_csv(chemeleon_path)
 
     metrics = [
         ("mae_mean", "MAE"),
@@ -371,19 +371,19 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
 
     for strategy in STRATEGY_ORDER:
         xgb_strat = xgb_df[xgb_df["strategy"] == strategy].copy()
-        chemprop_strat = chemprop_df[chemprop_df["strategy"] == strategy].copy()
+        chemeleon_strat = chemeleon_df[chemeleon_df["strategy"] == strategy].copy()
 
-        if xgb_strat.empty and chemprop_strat.empty:
+        if xgb_strat.empty and chemeleon_strat.empty:
             continue
 
         for metric_col, ylabel in metrics:
             out_path = output_dir / f"combined_{strategy}_{metric_col.replace('_mean', '')}.png"
             plot_model_comparison_bars(
-                data_by_model={"xgboost": xgb_strat, "chemprop": chemprop_strat},
+                data_by_model={"xgboost": xgb_strat, "chemeleon": chemeleon_strat},
                 endpoint_col="endpoint",
                 metric_col=metric_col,
                 ylabel=ylabel,
-                title=f"{ylabel} — {strategy} split: XGBoost vs Chemprop",
+                title=f"{ylabel} — {strategy} split: XGBoost vs CheMeleon",
                 output_path=out_path,
                 dpi=dpi,
             )
@@ -398,8 +398,8 @@ def main(
         PROCESSED_DATA_DIR / "2.11-seal-scaffold-vs-random", help="Output directory"
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
-    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -428,23 +428,21 @@ def main(
     cluster_folds = cluster_folds[cluster_folds["repeat"] == 0]
 
     # Skip training if key outputs already exist
-    if (model_dir / "summary_metrics.csv").exists():
+    if (model_dir / "predictions.parquet").exists():
         logger.info(f"Existing {model} outputs found — regenerating figures only")
         summary_df = pd.read_csv(model_dir / "summary_metrics.csv")
         agg_df = pd.read_csv(model_dir / "aggregated_metrics.csv")
         dist_df_loaded = pd.read_csv(model_dir / "distance_stats.csv")
-        # Reconstruct distance_rows from summary if dist_df_loaded only has stats
-        # (distance_distributions.png needs per-molecule distances — skip regeneration if unavailable)
-        # We'll still regenerate the metric and strategy figures from agg/summary
         _save_figures(summary_df, agg_df, pd.DataFrame(columns=["strategy", "nn1_distance"]),
                       dist_df_loaded, model_dir, dpi)
         logger.info(f"Figures regenerated in {model_dir}")
         return
 
-    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    chemprop_cache = model_dir / "pred_cache"
 
     # ── 2. Train and evaluate per strategy per endpoint ───────────────
     metric_rows = []
+    pred_rows = []
     distance_rows = []  # per-molecule test-to-train 1-NN distances
 
     for ep in ENDPOINTS:
@@ -471,7 +469,7 @@ def main(
         else:
             y_all = raw_values
 
-        # Always: protonate (needed for both XGBoost and Chemprop)
+        # Always: protonate (needed for both XGBoost and CheMeleon)
         prot_smiles = protonate_at_ph(smiles, ph)
 
         # XGBoost only: feature computation
@@ -526,10 +524,9 @@ def main(
                     test_idx_arr = np.where(test_mask)[0]
                     train_prot = [prot_smiles[i] for i in train_idx]
                     test_prot = [prot_smiles[i] for i in test_idx_arr]
-                    y_pred = train_chemprop(train_prot, y_tr, test_prot,
-                                           cache_dir=chemprop_cache,
-                                           cache_key=f"2.11_{ep}_{strategy}_fold{fold_id}",
-                                           checkpoint_dir=model_dir / "models")
+                    y_pred = train_chemeleon(train_prot, y_tr, test_prot,
+                                            cache_dir=chemprop_cache,
+                                            cache_key=f"2.11_{ep}_{strategy}_fold{fold_id}")
 
                 # Competition metrics
                 mae = mean_absolute_error(y_te, y_pred)
@@ -552,6 +549,17 @@ def main(
                     "rae": rae,
                 })
 
+                te_names = names[test_mask]
+                for i in range(len(y_te)):
+                    pred_rows.append({
+                        "Molecule Name": te_names[i],
+                        "endpoint": ep,
+                        "strategy": strategy,
+                        "fold": fold_id,
+                        "y_true": float(y_te[i]),
+                        "y_pred": float(y_pred[i]),
+                    })
+
                 # Test-to-train 1-NN distances
                 test_idx = np.where(test_mask)[0]
                 train_idx = np.where(train_mask)[0]
@@ -570,7 +578,11 @@ def main(
                 f"sizes={[int((fold_ids == f).sum()) for f in unique_folds]}"
             )
 
-    # ── 3. Save per-fold metrics ──────────────────────────────────────
+    # ── 3. Save per-fold metrics and per-molecule predictions ─────────
+    pred_df = pd.DataFrame(pred_rows)
+    pred_df.to_parquet(model_dir / "predictions.parquet", index=False)
+    logger.info(f"Saved predictions.parquet ({len(pred_df)} rows)")
+
     summary_df = pd.DataFrame(metric_rows)
     summary_df.to_csv(model_dir / "summary_metrics.csv", index=False)
     logger.info(f"Saved summary_metrics.csv ({len(summary_df)} rows)")

--- a/notebooks/2.12-seal-split-variance.py
+++ b/notebooks/2.12-seal-split-variance.py
@@ -8,7 +8,7 @@ intervals rather than single point estimates.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.12-seal-split-variance.py
-    pixi run -e cheminformatics python notebooks/2.12-seal-split-variance.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.12-seal-split-variance.py --model chemeleon
     pixi run -e cheminformatics python notebooks/2.12-seal-split-variance.py --combined
 
 Outputs (per model, under data/processed/2.12-seal-split-variance/<model>/):
@@ -42,7 +42,7 @@ from scipy.stats import kendalltau, mannwhitneyu, spearmanr
 from sklearn.metrics import mean_absolute_error, r2_score
 from sklearn.preprocessing import StandardScaler
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -370,15 +370,15 @@ def _save_figures(
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' variance_summary.csv and produce combined comparison figures."""
     xgb_path = output_dir / "xgboost" / "variance_summary.csv"
-    chemprop_path = output_dir / "chemprop" / "variance_summary.csv"
+    chemeleon_path = output_dir / "chemeleon" / "variance_summary.csv"
 
-    missing = [p for p in [xgb_path, chemprop_path] if not p.exists()]
+    missing = [p for p in [xgb_path, chemeleon_path] if not p.exists()]
     if missing:
         logger.error(f"Cannot generate combined figures — missing: {[str(p) for p in missing]}")
         return
 
     xgb_df = pd.read_csv(xgb_path)
-    chemprop_df = pd.read_csv(chemprop_path)
+    chemeleon_df = pd.read_csv(chemeleon_path)
 
     metrics = [
         ("mae_mean", "MAE"),
@@ -389,19 +389,19 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
 
     for strategy in STRATEGY_ORDER:
         xgb_strat = xgb_df[xgb_df["strategy"] == strategy].copy()
-        chemprop_strat = chemprop_df[chemprop_df["strategy"] == strategy].copy()
+        chemeleon_strat = chemeleon_df[chemeleon_df["strategy"] == strategy].copy()
 
-        if xgb_strat.empty and chemprop_strat.empty:
+        if xgb_strat.empty and chemeleon_strat.empty:
             continue
 
         for metric_col, ylabel in metrics:
             out_path = output_dir / f"combined_{strategy}_{metric_col.replace('_mean', '')}.png"
             plot_model_comparison_bars(
-                data_by_model={"xgboost": xgb_strat, "chemprop": chemprop_strat},
+                data_by_model={"xgboost": xgb_strat, "chemeleon": chemeleon_strat},
                 endpoint_col="endpoint",
                 metric_col=metric_col,
                 ylabel=ylabel,
-                title=f"{ylabel} variance ({strategy} split): XGBoost vs Chemprop",
+                title=f"{ylabel} variance ({strategy} split): XGBoost vs CheMeleon",
                 output_path=out_path,
                 dpi=dpi,
             )
@@ -417,8 +417,8 @@ def main(
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     n_random_repeats: int = typer.Option(5, help="Number of random split repeats"),
-    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -442,7 +442,7 @@ def main(
     logger.info(f"Cluster folds: {len(cluster_folds)} rows, {n_cluster_repeats} repeats")
 
     # Skip training if key outputs already exist
-    if (model_dir / "summary_metrics.csv").exists():
+    if (model_dir / "predictions.parquet").exists():
         logger.info(f"Existing {model} outputs found — regenerating figures only")
         summary_df = pd.read_csv(model_dir / "summary_metrics.csv")
         repeat_agg = pd.read_csv(model_dir / "repeat_aggregates.csv")
@@ -451,10 +451,11 @@ def main(
         logger.info(f"Figures regenerated in {model_dir}")
         return
 
-    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    chemprop_cache = model_dir / "pred_cache"
 
     # ── 2. Train and evaluate per strategy per repeat per endpoint ────
     metric_rows = []
+    pred_rows = []
 
     for ep in ENDPOINTS:
         ph = ENDPOINT_PH[ep]
@@ -476,7 +477,7 @@ def main(
         else:
             y_all = raw_values
 
-        # Always: protonate (needed for both XGBoost and Chemprop)
+        # Always: protonate (needed for both XGBoost and CheMeleon)
         prot_smiles = protonate_at_ph(smiles, ph)
 
         # XGBoost only: feature computation (shared across all repeats)
@@ -515,10 +516,9 @@ def main(
                 else:
                     train_prot = [prot_smiles[i] for i in np.where(train_mask)[0]]
                     test_prot = [prot_smiles[i] for i in np.where(test_mask)[0]]
-                    y_pred = train_chemprop(train_prot, y_tr, test_prot,
-                                           cache_dir=chemprop_cache,
-                                           cache_key=f"2.12_{ep}_random_r{repeat}_fold{fold_id}",
-                                           checkpoint_dir=model_dir / "models")
+                    y_pred = train_chemeleon(train_prot, y_tr, test_prot,
+                                            cache_dir=chemprop_cache,
+                                            cache_key=f"2.12_{ep}_random_r{repeat}_fold{fold_id}")
 
                 mae = mean_absolute_error(y_te, y_pred)
                 r2 = r2_score(y_te, y_pred)
@@ -540,6 +540,18 @@ def main(
                     "kendall_tau": kt,
                     "rae": rae,
                 })
+
+                te_names = names[test_mask]
+                for i in range(len(y_te)):
+                    pred_rows.append({
+                        "Molecule Name": te_names[i],
+                        "endpoint": ep,
+                        "strategy": "random",
+                        "repeat": repeat,
+                        "fold": fold_id,
+                        "y_true": float(y_te[i]),
+                        "y_pred": float(y_pred[i]),
+                    })
 
         logger.info(f"    random: {n_random_repeats} repeats done")
 
@@ -569,10 +581,9 @@ def main(
                 else:
                     train_prot = [prot_smiles[i] for i in np.where(train_mask)[0]]
                     test_prot = [prot_smiles[i] for i in np.where(test_mask)[0]]
-                    y_pred = train_chemprop(train_prot, y_tr, test_prot,
-                                           cache_dir=chemprop_cache,
-                                           cache_key=f"2.12_{ep}_cluster_r{repeat}_fold{fold_id}",
-                                           checkpoint_dir=model_dir / "models")
+                    y_pred = train_chemeleon(train_prot, y_tr, test_prot,
+                                            cache_dir=chemprop_cache,
+                                            cache_key=f"2.12_{ep}_cluster_r{repeat}_fold{fold_id}")
 
                 mae = mean_absolute_error(y_te, y_pred)
                 r2 = r2_score(y_te, y_pred)
@@ -595,9 +606,25 @@ def main(
                     "rae": rae,
                 })
 
+                te_names = names[test_mask]
+                for i in range(len(y_te)):
+                    pred_rows.append({
+                        "Molecule Name": te_names[i],
+                        "endpoint": ep,
+                        "strategy": "cluster",
+                        "repeat": repeat,
+                        "fold": fold_id,
+                        "y_true": float(y_te[i]),
+                        "y_pred": float(y_pred[i]),
+                    })
+
         logger.info(f"    cluster: {n_cluster_repeats} repeats done")
 
-    # ── 3. Save per-fold metrics ──────────────────────────────────────
+    # ── 3. Save per-fold metrics and per-molecule predictions ─────────
+    pred_df = pd.DataFrame(pred_rows)
+    pred_df.to_parquet(model_dir / "predictions.parquet", index=False)
+    logger.info(f"Saved predictions.parquet ({len(pred_df)} rows)")
+
     summary_df = pd.DataFrame(metric_rows)
     summary_df.to_csv(model_dir / "summary_metrics.csv", index=False)
     logger.info(f"Saved summary_metrics.csv ({len(summary_df)} rows)")

--- a/notebooks/2.13-seal-molecular-variants.py
+++ b/notebooks/2.13-seal-molecular-variants.py
@@ -7,13 +7,13 @@ If ECFP fingerprints change significantly for minor structural changes, models
 produce inconsistent predictions — exposing fingerprint artifacts rather than
 learned chemistry.
 
-Supports XGBoost (ECFP4 + RDKit 2D descriptors, Optuna-tuned) and Chemprop
-D-MPNN. Use --combined to generate side-by-side comparison figures once both
+Supports XGBoost (ECFP4 + RDKit 2D descriptors, Optuna-tuned) and CheMeleon.
+Use --combined to generate side-by-side comparison figures once both
 models have been run.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.13-seal-molecular-variants.py
-    pixi run -e cheminformatics python notebooks/2.13-seal-molecular-variants.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.13-seal-molecular-variants.py --model chemeleon
     pixi run -e cheminformatics python notebooks/2.13-seal-molecular-variants.py --combined
 
 Model-agnostic outputs (saved directly to output_dir):
@@ -51,7 +51,7 @@ from rdkit.Chem.Scaffolds import MurckoScaffold
 from rdkit.ML.Descriptors.MoleculeDescriptors import MolecularDescriptorCalculator
 from sklearn.preprocessing import StandardScaler
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -369,9 +369,9 @@ def _generate_figures(
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' consistency metrics and produce comparison figures."""
     xgb_path = output_dir / "xgboost" / "consistency_summary.csv"
-    chemprop_path = output_dir / "chemprop" / "consistency_summary.csv"
+    chemeleon_path = output_dir / "chemeleon" / "consistency_summary.csv"
 
-    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemeleon", chemeleon_path)] if not p.exists()]
     if missing:
         logger.error(f"Missing results for: {missing}. Run those models first.")
         return
@@ -380,7 +380,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     combined_dir.mkdir(parents=True, exist_ok=True)
 
     xgb = pd.read_csv(xgb_path)
-    chemprop = pd.read_csv(chemprop_path)
+    chemeleon = pd.read_csv(chemeleon_path)
 
     # Merge on (variant_type, endpoint) and save comparison CSV
     merge_cols = ["variant_type", "endpoint", "pred_cv_mean", "pred_cv_median",
@@ -389,8 +389,8 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
         xgb[merge_cols].rename(columns={c: f"{c}_xgboost" for c in merge_cols
                                         if c not in ("variant_type", "endpoint")})
         .merge(
-            chemprop[merge_cols].rename(columns={c: f"{c}_chemprop" for c in merge_cols
-                                                 if c not in ("variant_type", "endpoint")}),
+            chemeleon[merge_cols].rename(columns={c: f"{c}_chemeleon" for c in merge_cols
+                                                  if c not in ("variant_type", "endpoint")}),
             on=["variant_type", "endpoint"],
         )
     )
@@ -399,10 +399,10 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
 
     for vtype in VARIANT_ORDER:
         xgb_vt = xgb[xgb["variant_type"] == vtype].copy()
-        chemprop_vt = chemprop[chemprop["variant_type"] == vtype].copy()
-        if xgb_vt.empty or chemprop_vt.empty:
+        chemeleon_vt = chemeleon[chemeleon["variant_type"] == vtype].copy()
+        if xgb_vt.empty or chemeleon_vt.empty:
             continue
-        vt_data = {"xgboost": xgb_vt, "chemprop": chemprop_vt}
+        vt_data = {"xgboost": xgb_vt, "chemeleon": chemeleon_vt}
         vtype_label = vtype.replace("_", " ").title()
 
         for metric, ylabel, fname in [
@@ -411,7 +411,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
         ]:
             plot_model_comparison_bars(
                 vt_data, "endpoint", metric, ylabel,
-                f"{ylabel} — XGBoost vs Chemprop ({vtype_label})",
+                f"{ylabel} — XGBoost vs CheMeleon ({vtype_label})",
                 combined_dir / f"{fname}_comparison.png", dpi=dpi,
             )
             logger.info(f"Saved {fname}_comparison.png")
@@ -426,8 +426,8 @@ def main(
     ),
     dpi: int = typer.Option(DEFAULT_DPI, help="DPI for saved figures"),
     max_scaffold_group_size: int = typer.Option(20, help="Max scaffold group size for analysis"),
-    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon comparison figures"),
 ) -> None:
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -436,8 +436,8 @@ def main(
         _generate_combined_figures(output_dir, dpi)
         return
 
-    if model not in ("xgboost", "chemprop"):
-        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+    if model not in ("xgboost", "chemeleon"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemeleon.")
         raise typer.Exit(1)
 
     _migrate_flat_outputs(output_dir)
@@ -626,7 +626,7 @@ def main(
     )
 
     # ── Skip training if model outputs already exist ──────────────────
-    if (model_dir / "consistency_metrics.csv").exists():
+    if (model_dir / "predictions.parquet").exists():
         logger.info(f"Existing {model} outputs found — regenerating figures only")
         consistency_df = pd.read_csv(model_dir / "consistency_metrics.csv")
         summary_df = pd.read_csv(model_dir / "consistency_summary.csv")
@@ -640,9 +640,9 @@ def main(
     oof_predictions: dict[str, dict[str, float]] = {}
 
     optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
-    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    chemprop_cache = model_dir / "pred_cache"
 
-    # Protonated SMILES per molecule index, keyed by pH (always computed for Chemprop;
+    # Protonated SMILES per molecule index, keyed by pH (always computed for CheMeleon;
     # for XGBoost this is also the basis for feature computation below).
     prot_smiles_by_ph: dict[float, list[str]] = {}
     unique_phs = sorted(set(ENDPOINT_PH.values()))
@@ -705,15 +705,14 @@ def main(
                 )
                 y_pred = model_obj.predict(X_te)
             else:
-                # Chemprop: use protonated SMILES per pH, indexed back to ep subset
+                # CheMeleon: use protonated SMILES per pH, indexed back to ep subset
                 ep_indices = np.where(mask)[0]
                 train_prot_ep = [prot_smiles_by_ph[ph][ep_indices[i]] for i in np.where(train_mask)[0]]
                 test_prot_ep = [prot_smiles_by_ph[ph][ep_indices[i]] for i in np.where(test_mask)[0]]
-                y_pred = train_chemprop(
+                y_pred = train_chemeleon(
                     train_prot_ep, y_tr, test_prot_ep,
                     cache_dir=chemprop_cache,
-                    cache_key=f"2.13_{ep}_cluster_fold{fold_id}",
-                    checkpoint_dir=model_dir / "models",
+                    cache_key=f"2.13_{ep}_cluster_fold{fold_id}"
                 )
 
             # Store out-of-fold predictions
@@ -724,6 +723,14 @@ def main(
                 oof_predictions[name][ep] = {"pred": float(pred), "true": float(true)}
 
     logger.info(f"Collected predictions for {len(oof_predictions)} molecules")
+
+    pred_rows = [
+        {"Molecule Name": name, "endpoint": ep, "y_true": v["true"], "y_pred": v["pred"]}
+        for name, ep_dict in oof_predictions.items()
+        for ep, v in ep_dict.items()
+    ]
+    pd.DataFrame(pred_rows).to_parquet(model_dir / "predictions.parquet", index=False)
+    logger.info(f"Saved predictions.parquet ({len(pred_rows)} rows)")
 
     # ── 5. Compute within-group consistency ───────────────────────────
     logger.info("Computing within-group prediction consistency")

--- a/notebooks/2.15-zalte-resonance-variants.py
+++ b/notebooks/2.15-zalte-resonance-variants.py
@@ -2,19 +2,19 @@
 """Molecular variant consistency analysis: Resonance Structures.
 
 Analyzes prediction sensitivity to resonance form representation by loading
-pre-generated resonance forms from 2.14, training models (XGBoost or Chemprop),
+pre-generated resonance forms from 2.14, training models (XGBoost or CheMeleon),
 and comparing predictions across canonical and resonance-form SMILES.
 
 ECFP4 fingerprint instability analysis (Tanimoto distances between resonance
 forms) is model-agnostic and always computed. Feature computation for XGBoost
 training (ECFP4 + RDKit 2D) is XGBoost-only.
 
-Supports XGBoost (ECFP4 + RDKit 2D descriptors, Optuna-tuned) and Chemprop
-D-MPNN. Use --combined to generate side-by-side comparison figures.
+Supports XGBoost (ECFP4 + RDKit 2D descriptors, Optuna-tuned) and CheMeleon.
+Use --combined to generate side-by-side comparison figures.
 
 Usage:
     pixi run -e cheminformatics python notebooks/2.15-zalte-resonance-variants.py
-    pixi run -e cheminformatics python notebooks/2.15-zalte-resonance-variants.py --model chemprop
+    pixi run -e cheminformatics python notebooks/2.15-zalte-resonance-variants.py --model chemeleon
     pixi run -e cheminformatics python notebooks/2.15-zalte-resonance-variants.py --combined
 
 Model-agnostic outputs (saved to output_dir):
@@ -48,7 +48,7 @@ from rdkit.ML.Descriptors.MoleculeDescriptors import MolecularDescriptorCalculat
 from sklearn.preprocessing import StandardScaler
 from tqdm import tqdm
 
-from polaris_generalization.chemprop_utils import train_chemprop
+from polaris_generalization.chemprop_utils import train_chemeleon
 from polaris_generalization.config import INTERIM_DATA_DIR, PROCESSED_DATA_DIR
 from polaris_generalization.tuning import tune_xgboost
 from polaris_generalization.visualization import (
@@ -293,9 +293,9 @@ def _generate_figures(
 def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     """Load both models' consistency summaries and produce comparison figures."""
     xgb_path = output_dir / "xgboost" / "consistency_summary.csv"
-    chemprop_path = output_dir / "chemprop" / "consistency_summary.csv"
+    chemeleon_path = output_dir / "chemeleon" / "consistency_summary.csv"
 
-    missing = [m for m, p in [("xgboost", xgb_path), ("chemprop", chemprop_path)] if not p.exists()]
+    missing = [m for m, p in [("xgboost", xgb_path), ("chemeleon", chemeleon_path)] if not p.exists()]
     if missing:
         logger.error(f"Missing results for: {missing}. Run those models first.")
         return
@@ -304,7 +304,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     combined_dir.mkdir(parents=True, exist_ok=True)
 
     xgb = pd.read_csv(xgb_path)
-    chemprop = pd.read_csv(chemprop_path)
+    chemeleon = pd.read_csv(chemeleon_path)
 
     # Comparison CSV
     merge_cols = ["endpoint", "baseline_rmse", "rms_minrd", "rms_maxrd",
@@ -312,7 +312,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     comparison_df = (
         xgb[merge_cols].rename(columns={c: f"{c}_xgboost" for c in merge_cols if c != "endpoint"})
         .merge(
-            chemprop[merge_cols].rename(columns={c: f"{c}_chemprop" for c in merge_cols if c != "endpoint"}),
+            chemeleon[merge_cols].rename(columns={c: f"{c}_chemeleon" for c in merge_cols if c != "endpoint"}),
             on="endpoint",
         )
     )
@@ -320,7 +320,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     logger.info("Saved consistency_comparison.csv")
 
     # Grouped bar charts
-    data_by_model = {"xgboost": xgb, "chemprop": chemprop}
+    data_by_model = {"xgboost": xgb, "chemeleon": chemeleon}
     for metric, ylabel, fname in [
         ("pct_swing", "% RMSE swing (Max−Min)", "pct_swing_comparison"),
         ("rms_resrange", "RMS resonance prediction range", "rms_resrange_comparison"),
@@ -328,7 +328,7 @@ def _generate_combined_figures(output_dir: Path, dpi: int) -> None:
     ]:
         plot_model_comparison_bars(
             data_by_model, "endpoint", metric, ylabel,
-            f"{ylabel} — XGBoost vs Chemprop",
+            f"{ylabel} — XGBoost vs CheMeleon",
             combined_dir / f"{fname}.png", dpi=dpi,
         )
         logger.info(f"Saved {fname}.png")
@@ -345,8 +345,8 @@ def main(
         PROCESSED_DATA_DIR / "2.15-zalte-resonance-variants"
     ),
     dpi: int = typer.Option(DEFAULT_DPI),
-    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemprop"),
-    combined: bool = typer.Option(False, help="Generate combined XGBoost+Chemprop comparison figures"),
+    model: str = typer.Option("xgboost", help="Model architecture: xgboost or chemeleon"),
+    combined: bool = typer.Option(False, help="Generate combined XGBoost+CheMeleon comparison figures"),
 ):
     set_style()
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -355,8 +355,8 @@ def main(
         _generate_combined_figures(output_dir, dpi)
         return
 
-    if model not in ("xgboost", "chemprop"):
-        logger.error(f"Unknown model: {model}. Choose xgboost or chemprop.")
+    if model not in ("xgboost", "chemeleon"):
+        logger.error(f"Unknown model: {model}. Choose xgboost or chemeleon.")
         raise typer.Exit(1)
 
     _migrate_flat_outputs(output_dir)
@@ -442,7 +442,7 @@ def main(
     # -----------------------------
     # Skip-training check
     # -----------------------------
-    if (model_dir / "consistency_metrics.csv").exists():
+    if (model_dir / "predictions.parquet").exists():
         logger.info(f"Existing {model} outputs found — regenerating figures only")
         consistency_df = pd.read_csv(model_dir / "consistency_metrics.csv")
         summary_df = pd.read_csv(model_dir / "consistency_summary.csv")
@@ -458,7 +458,7 @@ def main(
     oof_predictions = {}
 
     optuna_cache = INTERIM_DATA_DIR / "optuna_cache"
-    chemprop_cache = INTERIM_DATA_DIR / "chemprop_pred_cache"
+    chemprop_cache = model_dir / "pred_cache"
 
     for ep in tqdm(ENDPOINTS, desc="Evaluating Endpoints"):
         ph = ENDPOINT_PH[ep]
@@ -521,7 +521,7 @@ def main(
                         "true": float(true),
                     }
             else:
-                # Chemprop: train once per fold, predict on all resonance forms in one shot.
+                # CheMeleon: train once per fold, predict on all resonance forms in one shot.
                 # Mirrors XGBoost: one model per fold, inference on the full augmented test set.
                 train_prot_fold = [train_smiles_prot[i] for i in np.where(tr)[0]]
 
@@ -537,12 +537,11 @@ def main(
                     all_res_smiles.extend(forms_prot)
                     mol_trues[name] = float(true)
 
-                # One train_chemprop call — model trained once, predicts on all resonance forms.
-                all_preds = train_chemprop(
+                # One train_chemeleon call — model trained once, predicts on all resonance forms.
+                all_preds = train_chemeleon(
                     train_prot_fold, y[tr], all_res_smiles,
                     cache_dir=chemprop_cache,
-                    cache_key=f"2.15_{ep}_cluster_fold{fold_id}_allres",
-                    checkpoint_dir=model_dir / "models",
+                    cache_key=f"2.15_{ep}_cluster_fold{fold_id}_allres"
                 )
 
                 for name, (s, e) in res_slices.items():
@@ -552,6 +551,21 @@ def main(
                         "preds": all_preds[s:e].tolist(),
                         "true": mol_trues[name],
                     }
+
+    # Flatten oof_predictions → predictions.parquet
+    pred_rows = []
+    for name, ep_dict in oof_predictions.items():
+        for ep, v in ep_dict.items():
+            for form_idx, y_pred_val in enumerate(v["preds"]):
+                pred_rows.append({
+                    "Molecule Name": name,
+                    "endpoint": ep,
+                    "form_idx": form_idx,
+                    "y_true": v["true"],
+                    "y_pred": y_pred_val,
+                })
+    pd.DataFrame(pred_rows).to_parquet(model_dir / "predictions.parquet", index=False)
+    logger.info(f"Saved predictions.parquet ({len(pred_rows)} rows)")
 
     # -----------------------------
     # RIGR-aligned metrics

--- a/scripts/combine.sh
+++ b/scripts/combine.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Generate combined XGBoost + CheMeleon comparison figures for all modeling notebooks.
+# Usage: bash scripts/combine.sh
+#
+# Requires both --model xgboost and --model chemeleon runs to have completed first
+# (i.e. both predictions.parquet files must exist for each notebook).
+# This script does no model training — it only reads existing outputs and produces figures.
+
+set -uo pipefail
+
+trap 'echo ""; echo "  !! Interrupted — aborting remaining jobs"; exit 130' INT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$REPO_ROOT/logs/combine"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+RUN_LOG="$LOG_DIR/run_${TIMESTAMP}.log"
+
+mkdir -p "$LOG_DIR"
+cd "$REPO_ROOT"
+
+PIXI="pixi run -e cheminformatics python"
+NB="notebooks"
+
+# ── Notebook list ──────────────────────────────────────────────────────────
+# Each entry: "log_stem|depends_on_stem|script|args..."
+# 2.10 sensitivity --combined is not supported; only main has combined figures.
+declare -a JOBS=(
+    "2.07_combined|-|$NB/2.07-seal-performance-distance.py|--combined"
+    "2.08_combined|-|$NB/2.08-seal-baseline-performance.py|--combined"
+    "2.09_combined|-|$NB/2.09-seal-iid-vs-ood-series.py|--combined"
+    "2.10_combined|-|$NB/2.10-seal-activity-cliff-eval.py|main --combined"
+    "2.11_combined|-|$NB/2.11-seal-scaffold-vs-random.py|--combined"
+    "2.12_combined|-|$NB/2.12-seal-split-variance.py|--combined"
+    "2.13_combined|-|$NB/2.13-seal-molecular-variants.py|--combined"
+    "2.15_combined|-|$NB/2.15-zalte-resonance-variants.py|--combined"
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+PASS=0; FAIL=0; SKIP=0
+declare -a FAILED_JOBS=()
+declare -A PASSED_STEMS=()
+
+log() { echo "$*" | tee -a "$RUN_LOG"; }
+
+run_job() {
+    local stem="$1" depends="$2" script="$3"
+    shift 3
+    local args=("$@")
+    local job_log="$LOG_DIR/${stem}_${TIMESTAMP}.log"
+
+    if [[ "$depends" != "-" ]] && [[ -z "${PASSED_STEMS[$depends]+x}" ]]; then
+        log ""
+        log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        log "  SKIP   $stem  (dependency '$depends' did not pass)"
+        (( SKIP++ )) || true
+        FAILED_JOBS+=("$stem (skipped: $depends failed)")
+        return
+    fi
+
+    log ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "  START  $stem"
+    log "  cmd:   $PIXI $script ${args[*]}"
+    log "  log:   $job_log"
+    log "  time:  $(date)"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    if $PIXI "$script" "${args[@]}" 2>&1 | tee "$job_log"; then
+        log "  ✓ DONE  $stem  ($(date))"
+        (( PASS++ )) || true
+        PASSED_STEMS[$stem]=1
+    else
+        local rc=$?
+        log "  ✗ FAIL  $stem  (exit $rc)"
+        (( FAIL++ )) || true
+        FAILED_JOBS+=("$stem")
+    fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────
+log "Combined figures run — $TIMESTAMP"
+log "Repo: $REPO_ROOT"
+log "Logs: $LOG_DIR"
+
+for job in "${JOBS[@]}"; do
+    IFS='|' read -r stem depends script args_str <<< "$job"
+    read -ra args <<< "$args_str"
+    run_job "$stem" "$depends" "$script" "${args[@]}"
+done
+
+# ── Summary ────────────────────────────────────────────────────────────────
+log ""
+log "══════════════════════════════════════════════════════════════"
+log "  SUMMARY  $TIMESTAMP"
+log "  passed: $PASS   failed: $FAIL"
+if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then
+    log "  FAILED JOBS:"
+    for j in "${FAILED_JOBS[@]}"; do
+        log "    - $j"
+    done
+fi
+log "══════════════════════════════════════════════════════════════"
+
+[[ $FAIL -eq 0 ]]

--- a/scripts/exploration.sh
+++ b/scripts/exploration.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Run all exploration/preprocessing notebooks sequentially, logging each to logs/exploration/.
+# These notebooks do not train models — they produce interim data, split files, and
+# characterization figures. Run this before any model training script.
+#
+# Usage: bash scripts/exploration.sh
+#
+# Order matters: 1.01 (data loader) must run before split notebooks (2.03–2.06),
+# and 2.14 (resonance generation) must run before 2.15 model training.
+
+set -uo pipefail
+
+trap 'echo ""; echo "  !! Interrupted — aborting remaining jobs"; exit 130' INT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$REPO_ROOT/logs/exploration"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+RUN_LOG="$LOG_DIR/run_${TIMESTAMP}.log"
+
+mkdir -p "$LOG_DIR"
+cd "$REPO_ROOT"
+
+PIXI="pixi run -e cheminformatics python"
+NB="notebooks"
+
+# ── Notebook list ──────────────────────────────────────────────────────────
+# Each entry: "log_stem|depends_on_stem|script|args..."
+# 1.01 must run first (produces interim parquet files everything else reads).
+# 2.14 (resonance generation) must run before 2.15 model training.
+declare -a JOBS=(
+    # ── Data loading (prerequisite for everything) ──────────────────────
+    "1.01_dataset_loader|-|$NB/1.01-seal-dataset-loader.py|"
+
+    # ── Initial explorations ────────────────────────────────────────────
+    "0.01_dataset_exploration|1.01_dataset_loader|$NB/0.01-seal-dataset-exploration.py|"
+    "0.02_ecfp_distance|1.01_dataset_loader|$NB/0.02-seal-ecfp-distance-exploration.py|"
+    "0.03_chembl_tanimoto|-|$NB/0.03-araripe-chembl-tanimoto.py|"
+
+    # ── Dataset characterization ────────────────────────────────────────
+    # 2.01 reads tanimoto_distance_matrix.npz → depends on 0.02
+    "2.01_chemical_space|0.02_ecfp_distance|$NB/2.01-seal-chemical-space-analysis.py|"
+    # 2.02 reads only expansion_tx.parquet → depends on 1.01
+    "2.02_target_distribution|1.01_dataset_loader|$NB/2.02-seal-target-distribution.py|"
+
+    # ── Split generation (produces fold parquets used by model notebooks) ─
+    # 2.03/2.04/2.05 read tanimoto_distance_matrix.npz → depend on 0.02
+    "2.03_cluster_split|0.02_ecfp_distance|$NB/2.03-seal-cluster-split.py|"
+    "2.04_time_split|0.02_ecfp_distance|$NB/2.04-seal-time-split.py|"
+    "2.05_target_split|0.02_ecfp_distance|$NB/2.05-seal-target-split.py|"
+
+    # ── Split quality analysis ──────────────────────────────────────────
+    "2.06_split_quality|2.03_cluster_split|$NB/2.06-seal-split-quality.py|"
+
+    # ── Resonance form generation (prerequisite for 2.15 model training) ─
+    "2.14_resonance_generation|1.01_dataset_loader|$NB/2.14-zalte-resonance-generation.py|"
+
+    # ── Additional analyses ─────────────────────────────────────────────
+    # 2.16 reads expansion_tx.parquet (1.01) + tanimoto_distance_matrix.npz (0.02)
+    "2.16_scaffold_boundary|0.02_ecfp_distance|$NB/2.16-araripe-scaffold-boundary.py|"
+    "3.02_framework_figure|-|$NB/3.02-seal-framework-figure.py|"
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+PASS=0; FAIL=0; SKIP=0
+declare -a FAILED_JOBS=()
+declare -A PASSED_STEMS=()
+
+log() { echo "$*" | tee -a "$RUN_LOG"; }
+
+run_job() {
+    local stem="$1" depends="$2" script="$3"
+    shift 3
+    local args=("$@")
+    local job_log="$LOG_DIR/${stem}_${TIMESTAMP}.log"
+
+    if [[ "$depends" != "-" ]] && [[ -z "${PASSED_STEMS[$depends]+x}" ]]; then
+        log ""
+        log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        log "  SKIP   $stem  (dependency '$depends' did not pass)"
+        (( SKIP++ )) || true
+        FAILED_JOBS+=("$stem (skipped: $depends failed)")
+        return
+    fi
+
+    log ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "  START  $stem"
+    log "  cmd:   $PIXI $script${args[*]:+ ${args[*]}}"
+    log "  log:   $job_log"
+    log "  time:  $(date)"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    if $PIXI "$script" "${args[@]}" 2>&1 | tee "$job_log"; then
+        log "  ✓ DONE  $stem  ($(date))"
+        (( PASS++ )) || true
+        PASSED_STEMS[$stem]=1
+    else
+        local rc=$?
+        log "  ✗ FAIL  $stem  (exit $rc)"
+        (( FAIL++ )) || true
+        FAILED_JOBS+=("$stem")
+    fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────
+log "Exploration run — $TIMESTAMP"
+log "Repo: $REPO_ROOT"
+log "Logs: $LOG_DIR"
+
+for job in "${JOBS[@]}"; do
+    IFS='|' read -r stem depends script args_str <<< "$job"
+    read -ra args <<< "$args_str"
+    run_job "$stem" "$depends" "$script" "${args[@]}"
+done
+
+# ── Summary ────────────────────────────────────────────────────────────────
+log ""
+log "══════════════════════════════════════════════════════════════"
+log "  SUMMARY  $TIMESTAMP"
+log "  passed: $PASS   failed: $FAIL"
+if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then
+    log "  FAILED JOBS:"
+    for j in "${FAILED_JOBS[@]}"; do
+        log "    - $j"
+    done
+fi
+log "══════════════════════════════════════════════════════════════"
+
+[[ $FAIL -eq 0 ]]

--- a/scripts/train_chemeleon.sh
+++ b/scripts/train_chemeleon.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Run all CheMeleon training notebooks sequentially, logging each to logs/chemeleon/.
+# Usage: bash scripts/train_chemeleon.sh
+# Skips any notebook whose predictions.parquet already exists.
+
+set -uo pipefail
+
+# Ctrl+C aborts the whole run, not just the current job.
+_interrupted=0
+trap '_interrupted=1; echo ""; echo "  !! Interrupted — aborting remaining jobs"; exit 130' INT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$REPO_ROOT/logs/chemeleon"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+RUN_LOG="$LOG_DIR/run_${TIMESTAMP}.log"
+
+mkdir -p "$LOG_DIR"
+cd "$REPO_ROOT"
+
+PIXI="pixi run -e cheminformatics python"
+NB="notebooks"
+
+# ── Notebook list ──────────────────────────────────────────────────────────
+# Each entry: "log_stem|depends_on_stem|script|args..."
+# depends_on_stem: name of a prior stem that must have PASSED, or "-" for none.
+# 2.10 sensitivity depends on 2.10 main completing successfully.
+declare -a JOBS=(
+    "2.07_chemeleon|-|$NB/2.07-seal-performance-distance.py|--model chemeleon"
+    "2.08_chemeleon|-|$NB/2.08-seal-baseline-performance.py|--model chemeleon"
+    "2.09_chemeleon|-|$NB/2.09-seal-iid-vs-ood-series.py|--model chemeleon"
+    "2.10_chemeleon_main|-|$NB/2.10-seal-activity-cliff-eval.py|main --model chemeleon"
+    "2.10_chemeleon_sensitivity|2.10_chemeleon_main|$NB/2.10-seal-activity-cliff-eval.py|sensitivity --model chemeleon"
+    "2.11_chemeleon|-|$NB/2.11-seal-scaffold-vs-random.py|--model chemeleon"
+    "2.12_chemeleon|-|$NB/2.12-seal-split-variance.py|--model chemeleon"
+    "2.13_chemeleon|-|$NB/2.13-seal-molecular-variants.py|--model chemeleon"
+    "2.15_chemeleon|-|$NB/2.15-zalte-resonance-variants.py|--model chemeleon"
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+PASS=0; FAIL=0; SKIP=0
+declare -a FAILED_JOBS=()
+declare -A PASSED_STEMS=()  # tracks which stems completed successfully
+
+log() { echo "$*" | tee -a "$RUN_LOG"; }
+
+run_job() {
+    local stem="$1" depends="$2" script="$3"
+    shift 3
+    local args=("$@")
+    local job_log="$LOG_DIR/${stem}_${TIMESTAMP}.log"
+
+    # Skip if a required predecessor failed or was skipped.
+    if [[ "$depends" != "-" ]] && [[ -z "${PASSED_STEMS[$depends]+x}" ]]; then
+        log ""
+        log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        log "  SKIP   $stem  (dependency '$depends' did not pass)"
+        (( SKIP++ )) || true
+        FAILED_JOBS+=("$stem (skipped: $depends failed)")
+        return
+    fi
+
+    log ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "  START  $stem"
+    log "  cmd:   $PIXI $script ${args[*]}"
+    log "  log:   $job_log"
+    log "  time:  $(date)"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    if $PIXI "$script" "${args[@]}" 2>&1 | tee "$job_log"; then
+        log "  ✓ DONE  $stem  ($(date))"
+        (( PASS++ )) || true
+        PASSED_STEMS[$stem]=1
+    else
+        local rc=$?
+        log "  ✗ FAIL  $stem  (exit $rc)"
+        (( FAIL++ )) || true
+        FAILED_JOBS+=("$stem")
+    fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────
+log "CheMeleon training run — $TIMESTAMP"
+log "Repo: $REPO_ROOT"
+log "Logs: $LOG_DIR"
+
+for job in "${JOBS[@]}"; do
+    IFS='|' read -r stem depends script args_str <<< "$job"
+    # Split args string into array
+    read -ra args <<< "$args_str"
+    run_job "$stem" "$depends" "$script" "${args[@]}"
+done
+
+# ── Summary ────────────────────────────────────────────────────────────────
+log ""
+log "══════════════════════════════════════════════════════════════"
+log "  SUMMARY  $TIMESTAMP"
+log "  passed: $PASS   failed: $FAIL"
+if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then
+    log "  FAILED JOBS:"
+    for j in "${FAILED_JOBS[@]}"; do
+        log "    - $j"
+    done
+fi
+log "══════════════════════════════════════════════════════════════"
+
+[[ $FAIL -eq 0 ]]

--- a/scripts/train_xgboost.sh
+++ b/scripts/train_xgboost.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Run all XGBoost training notebooks sequentially, logging each to logs/xgboost/.
+# Usage: bash scripts/train_xgboost.sh
+# Skips any notebook whose predictions.parquet already exists.
+
+set -uo pipefail
+
+# Ctrl+C aborts the whole run, not just the current job.
+trap 'echo ""; echo "  !! Interrupted — aborting remaining jobs"; exit 130' INT
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$REPO_ROOT/logs/xgboost"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+RUN_LOG="$LOG_DIR/run_${TIMESTAMP}.log"
+
+mkdir -p "$LOG_DIR"
+cd "$REPO_ROOT"
+
+PIXI="pixi run -e cheminformatics python"
+NB="notebooks"
+
+# ── Notebook list ──────────────────────────────────────────────────────────
+# Each entry: "log_stem|depends_on_stem|script|args..."
+# depends_on_stem: name of a prior stem that must have PASSED, or "-" for none.
+# 2.10 sensitivity depends on 2.10 main completing successfully.
+declare -a JOBS=(
+    "2.07_xgboost|-|$NB/2.07-seal-performance-distance.py|--model xgboost"
+    "2.08_xgboost|-|$NB/2.08-seal-baseline-performance.py|--model xgboost"
+    "2.09_xgboost|-|$NB/2.09-seal-iid-vs-ood-series.py|--model xgboost"
+    "2.10_xgboost_main|-|$NB/2.10-seal-activity-cliff-eval.py|main --model xgboost"
+    "2.10_xgboost_sensitivity|2.10_xgboost_main|$NB/2.10-seal-activity-cliff-eval.py|sensitivity --model xgboost"
+    "2.11_xgboost|-|$NB/2.11-seal-scaffold-vs-random.py|--model xgboost"
+    "2.12_xgboost|-|$NB/2.12-seal-split-variance.py|--model xgboost"
+    "2.13_xgboost|-|$NB/2.13-seal-molecular-variants.py|--model xgboost"
+    "2.15_xgboost|-|$NB/2.15-zalte-resonance-variants.py|--model xgboost"
+)
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+PASS=0; FAIL=0; SKIP=0
+declare -a FAILED_JOBS=()
+declare -A PASSED_STEMS=()
+
+log() { echo "$*" | tee -a "$RUN_LOG"; }
+
+run_job() {
+    local stem="$1" depends="$2" script="$3"
+    shift 3
+    local args=("$@")
+    local job_log="$LOG_DIR/${stem}_${TIMESTAMP}.log"
+
+    if [[ "$depends" != "-" ]] && [[ -z "${PASSED_STEMS[$depends]+x}" ]]; then
+        log ""
+        log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+        log "  SKIP   $stem  (dependency '$depends' did not pass)"
+        (( SKIP++ )) || true
+        FAILED_JOBS+=("$stem (skipped: $depends failed)")
+        return
+    fi
+
+    log ""
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    log "  START  $stem"
+    log "  cmd:   $PIXI $script ${args[*]}"
+    log "  log:   $job_log"
+    log "  time:  $(date)"
+    log "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    if $PIXI "$script" "${args[@]}" 2>&1 | tee "$job_log"; then
+        log "  ✓ DONE  $stem  ($(date))"
+        (( PASS++ )) || true
+        PASSED_STEMS[$stem]=1
+    else
+        local rc=$?
+        log "  ✗ FAIL  $stem  (exit $rc)"
+        (( FAIL++ )) || true
+        FAILED_JOBS+=("$stem")
+    fi
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────
+log "XGBoost training run — $TIMESTAMP"
+log "Repo: $REPO_ROOT"
+log "Logs: $LOG_DIR"
+
+for job in "${JOBS[@]}"; do
+    IFS='|' read -r stem depends script args_str <<< "$job"
+    read -ra args <<< "$args_str"
+    run_job "$stem" "$depends" "$script" "${args[@]}"
+done
+
+# ── Summary ────────────────────────────────────────────────────────────────
+log ""
+log "══════════════════════════════════════════════════════════════"
+log "  SUMMARY  $TIMESTAMP"
+log "  passed: $PASS   failed: $FAIL"
+if [[ ${#FAILED_JOBS[@]} -gt 0 ]]; then
+    log "  FAILED JOBS:"
+    for j in "${FAILED_JOBS[@]}"; do
+        log "    - $j"
+    done
+fi
+log "══════════════════════════════════════════════════════════════"
+
+[[ $FAIL -eq 0 ]]

--- a/src/polaris_generalization/chemprop_utils.py
+++ b/src/polaris_generalization/chemprop_utils.py
@@ -6,10 +6,37 @@ from pathlib import Path
 import numpy as np
 from loguru import logger
 
+from polaris_generalization.config import INTERIM_DATA_DIR
+
 # Default training duration. Chemprop's own default is 50; increase for longer runs.
 DEFAULT_MAX_EPOCHS = 50
 ENSEMBLE_SIZE = 3
 MIN_VAL_FOR_EARLY_STOPPING = 5  # Skip early stopping if val set is smaller
+
+# Foundation model weights are version-pinned and shipped via the data/ folder so
+# collaborators inherit them without needing to download anything themselves.
+# Source: https://doi.org/10.5281/zenodo.15426600 (Zenodo record 15460715).
+CHEMELEON_WEIGHTS = INTERIM_DATA_DIR / "chemeleon_mp.pt"
+CHEMELEON_ZENODO_URL = "https://zenodo.org/records/15460715/files/chemeleon_mp.pt"
+
+
+def _ensure_chemeleon_weights(weights_path: Path = CHEMELEON_WEIGHTS) -> Path:
+    """Download CheMeleon weights from Zenodo into `weights_path` if missing."""
+    weights_path = Path(weights_path)
+    if weights_path.exists():
+        return weights_path
+
+    from urllib.request import urlretrieve
+
+    weights_path.parent.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        f"CheMeleon weights not found at {weights_path}; downloading from {CHEMELEON_ZENODO_URL}"
+    )
+    tmp_path = weights_path.with_suffix(weights_path.suffix + ".part")
+    urlretrieve(CHEMELEON_ZENODO_URL, tmp_path)
+    tmp_path.rename(weights_path)
+    logger.info(f"Saved CheMeleon weights to {weights_path}")
+    return weights_path
 
 
 def train_chemprop(
@@ -175,6 +202,166 @@ def train_chemprop(
 
     # Average predictions across ensemble members
     preds = np.mean(ensemble_preds, axis=0)
+
+    if cache_dir and safe_key:
+        cache_file = Path(cache_dir) / f"{safe_key}.npy"
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        np.save(cache_file, preds)
+
+    return preds
+
+
+def train_chemeleon(
+    train_smiles: list[str],
+    train_y: np.ndarray,
+    test_smiles: list[str],
+    max_epochs: int = DEFAULT_MAX_EPOCHS,
+    val_fraction: float = 0.1,
+    seed: int = 42,
+    cache_dir: Path | None = None,
+    cache_key: str | None = None,
+    checkpoint_dir: Path | None = None,
+    weights_path: Path = CHEMELEON_WEIGHTS,
+) -> np.ndarray:
+    """Fine-tune a CheMeleon foundation model for single-task regression.
+
+    Initializes the message-passing network from pre-trained CheMeleon weights
+    and trains a single model (no ensemble). The FFN is trained from scratch
+    with input_dim matched to CheMeleon's output dimension.
+
+    The CheMeleon foundation weights are downloaded from Zenodo into
+    `data/interim/chemeleon_mp.pt` on first call and reused on subsequent runs.
+
+    Cache files use the suffix _cm1 to distinguish from standard ensemble (_e3) cache.
+    """
+    env_cache = os.environ.get("CHEMPROP_CACHE_DIR")
+    if env_cache is not None:
+        cache_dir = Path(env_cache)
+
+    safe_key = None
+    if cache_dir and cache_key:
+        safe_key = cache_key.replace(">", "_").replace("<", "_").replace(" ", "_")
+        safe_key = f"{safe_key}_cm1"
+        cache_file = Path(cache_dir) / f"{safe_key}.npy"
+        if cache_file.exists():
+            logger.debug(f"CheMeleon cache hit: {cache_file.name}")
+            return np.load(cache_file)
+
+    import logging
+
+    import torch
+    from chemprop import data, featurizers, models
+    from chemprop import nn as chemprop_nn
+    from lightning import pytorch as pl
+    from lightning.pytorch.callbacks import EarlyStopping
+
+    logging.getLogger("lightning.pytorch").setLevel(logging.WARNING)
+    logging.getLogger("lightning").setLevel(logging.WARNING)
+
+    accelerator = "gpu" if torch.cuda.is_available() else "cpu"
+    devices = [0] if torch.cuda.is_available() else "auto"
+
+    pl.seed_everything(seed, workers=True)
+
+    weights_path = _ensure_chemeleon_weights(weights_path)
+    chemeleon_ckpt = torch.load(weights_path, weights_only=True)
+    mp = chemprop_nn.BondMessagePassing(**chemeleon_ckpt["hyper_parameters"])
+    mp.load_state_dict(chemeleon_ckpt["state_dict"])
+
+    featurizer = featurizers.SimpleMoleculeMolGraphFeaturizer()
+
+    rng = np.random.default_rng(seed)
+    n_total = len(train_smiles)
+    n_val = max(1, int(val_fraction * n_total))
+    val_idx = rng.choice(n_total, size=n_val, replace=False)
+    train_idx = np.setdiff1d(np.arange(n_total), val_idx)
+
+    all_pts = [data.MoleculeDatapoint.from_smi(smi, [float(y)]) for smi, y in zip(train_smiles, train_y)]
+    train_pts = [all_pts[j] for j in train_idx]
+    val_pts = [all_pts[j] for j in val_idx]
+    test_pts = [data.MoleculeDatapoint.from_smi(smi) for smi in test_smiles]
+
+    train_dset = data.MoleculeDataset(train_pts, featurizer)
+    val_dset = data.MoleculeDataset(val_pts, featurizer)
+    test_dset = data.MoleculeDataset(test_pts, featurizer)
+
+    scaler = train_dset.normalize_targets()
+    val_dset.normalize_targets(scaler)
+
+    output_transform = chemprop_nn.UnscaleTransform.from_standard_scaler(scaler)
+    agg = chemprop_nn.MeanAggregation()
+    ffn = chemprop_nn.RegressionFFN(n_tasks=1, output_transform=output_transform, input_dim=mp.output_dim, hidden_dim=1024, n_layers=2)
+    mpnn = models.MPNN(mp, agg, ffn, batch_norm=False)
+
+    train_loader = data.build_dataloader(train_dset, num_workers=4)
+    val_loader = data.build_dataloader(val_dset, shuffle=False, num_workers=4)
+    test_loader = data.build_dataloader(test_dset, shuffle=False, num_workers=4)
+
+    class _BestWeights(pl.Callback):
+        def __init__(self):
+            self.best_val_loss = float("inf")
+            self.best_state: dict | None = None
+
+        def on_validation_end(self, trainer, pl_module):
+            val_loss = trainer.callback_metrics.get("val_loss")
+            if val_loss is not None and float(val_loss) < self.best_val_loss:
+                self.best_val_loss = float(val_loss)
+                self.best_state = {k: v.clone() for k, v in pl_module.state_dict().items()}
+
+        def on_fit_end(self, trainer, pl_module):
+            if self.best_state is not None:
+                pl_module.load_state_dict(self.best_state)
+
+    best_weights = _BestWeights()
+    callbacks = [best_weights]
+    if n_val >= MIN_VAL_FOR_EARLY_STOPPING:
+        callbacks.append(EarlyStopping(monitor="val_loss", patience=10, mode="min"))
+    else:
+        logger.warning(f"Val set too small ({n_val} samples), skipping early stopping")
+
+    trainer = pl.Trainer(
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=True,
+        enable_model_summary=False,
+        accelerator=accelerator,
+        devices=devices,
+        max_epochs=max_epochs,
+        callbacks=callbacks,
+    )
+    trainer.fit(mpnn, train_loader, val_loader)
+    n_epochs_trained = min(trainer.current_epoch + 1, max_epochs)
+    logger.info(
+        f"CheMeleon | device={trainer.accelerator.__class__.__name__} | trained {n_epochs_trained}/{max_epochs} epochs | key={safe_key or 'no-cache'}"
+    )
+
+    if checkpoint_dir and safe_key:
+        checkpoint_dir = Path(checkpoint_dir)
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        trainer.save_checkpoint(checkpoint_dir / f"{safe_key}.ckpt")
+        config_file = checkpoint_dir / "training_config.json"
+        if not config_file.exists():
+            import json
+            config_file.write_text(
+                json.dumps(
+                    {
+                        "model": "CheMeleon",
+                        "weights_path": str(weights_path),
+                        "max_epochs": max_epochs,
+                        "val_fraction": val_fraction,
+                        "seed": seed,
+                        "n_ensemble": 1,
+                        "ffn_hidden_dim": 1024,
+                        "ffn_n_layers": 2,
+                        "mp_output_dim": mp.output_dim,
+                        "batch_norm": False,
+                    },
+                    indent=2,
+                )
+            )
+
+    preds_batched = trainer.predict(mpnn, test_loader)
+    preds = np.concatenate([p.numpy() for p in preds_batched], axis=0).squeeze(-1)
 
     if cache_dir and safe_key:
         cache_file = Path(cache_dir) / f"{safe_key}.npy"

--- a/src/polaris_generalization/tuning.py
+++ b/src/polaris_generalization/tuning.py
@@ -1,6 +1,7 @@
 """Shared Optuna-based hyperparameter tuning for XGBoost."""
 
 import json
+import os
 from pathlib import Path
 
 import numpy as np
@@ -8,12 +9,20 @@ import optuna
 from sklearn.model_selection import cross_val_score
 from xgboost import XGBRegressor
 
+# Use half the available CPUs so other processes (e.g. CheMeleon) can share the machine.
+# Split budget between CV-level parallelism and intra-tree parallelism to avoid
+# oversubscription: cv folds run in parallel, each XGBoost gets the remaining threads.
+_N_CV = 3
+_TOTAL_JOBS = max(1, (os.cpu_count() or 1) // 2)
+_XGB_JOBS = max(1, _TOTAL_JOBS // _N_CV)   # threads per XGBoost fit
+_CV_JOBS = _N_CV                            # parallel CV folds
+
 
 def tune_xgboost(
     X_train: np.ndarray,
     y_train: np.ndarray,
     n_trials: int = 30,
-    cv: int = 3,
+    cv: int = _N_CV,
     random_state: int = 42,
     cache_dir: Path | None = None,
     cache_key: str | None = None,
@@ -40,7 +49,8 @@ def tune_xgboost(
         cache_file = Path(cache_dir) / f"{safe_key}.json"
         if cache_file.exists():
             params = json.loads(cache_file.read_text())
-            model = XGBRegressor(**params, tree_method="hist", random_state=random_state, verbosity=0)
+            model = XGBRegressor(**params, tree_method="hist", n_jobs=_XGB_JOBS,
+                                 random_state=random_state, verbosity=0)
             model.fit(X_train, y_train)
             return model, params, None
 
@@ -57,8 +67,10 @@ def tune_xgboost(
             "reg_alpha": trial.suggest_float("reg_alpha", 0.0, 1.0),
             "reg_lambda": trial.suggest_float("reg_lambda", 0.5, 3.0),
         }
-        model = XGBRegressor(**params, tree_method="hist", random_state=random_state, verbosity=0)
-        scores = cross_val_score(model, X_train, y_train, cv=cv, scoring="neg_mean_absolute_error")
+        model = XGBRegressor(**params, tree_method="hist", n_jobs=_XGB_JOBS,
+                             random_state=random_state, verbosity=0)
+        scores = cross_val_score(model, X_train, y_train, cv=cv,
+                                 scoring="neg_mean_absolute_error", n_jobs=_CV_JOBS)
         return -scores.mean()
 
     optuna.logging.set_verbosity(optuna.logging.WARNING)
@@ -66,7 +78,8 @@ def tune_xgboost(
     study.optimize(objective, n_trials=n_trials)
 
     # Train final model with best params
-    best_model = XGBRegressor(**study.best_params, tree_method="hist", random_state=random_state, verbosity=0)
+    best_model = XGBRegressor(**study.best_params, tree_method="hist", n_jobs=_XGB_JOBS,
+                              random_state=random_state, verbosity=0)
     best_model.fit(X_train, y_train)
 
     # Save to cache

--- a/src/polaris_generalization/visualization.py
+++ b/src/polaris_generalization/visualization.py
@@ -8,8 +8,8 @@ import seaborn as sns
 
 DEFAULT_DPI = 150
 
-MODEL_COLORS = {"xgboost": "steelblue", "chemprop": "darkorange"}
-MODEL_LABELS = {"xgboost": "XGBoost", "chemprop": "Chemprop (D-MPNN)"}
+MODEL_COLORS = {"xgboost": "steelblue", "chemeleon": "darkorange"}
+MODEL_LABELS = {"xgboost": "XGBoost", "chemeleon": "CheMeleon"}
 
 
 def set_style():
@@ -31,7 +31,7 @@ def plot_model_comparison_bars(
 
     Parameters
     ----------
-    data_by_model : {"xgboost": df, "chemprop": df} where each df has endpoint_col and metric_col
+    data_by_model : {"xgboost": df, "chemeleon": df} where each df has endpoint_col and metric_col
     endpoint_col : column name for x-axis grouping (e.g. "endpoint")
     metric_col : column name for bar height (e.g. "r2")
     ylabel, title : axis labels


### PR DESCRIPTION
Replace Chemprop D-MPNN with CheMeleon foundation model                                                                                
                                                                                                                                         
  Swaps the second model backend from a from-scratch Chemprop D-MPNN to CheMeleon, a pre-trained BondMessagePassing foundation model
  fine-tuned per endpoint.                                                                                                               
  
  Changes:                                                                                                                               
  - chemprop_utils.py: adds train_chemeleon — auto-downloads weights from Zenodo on first call, same protonation/log-transform protocol
  as XGBoost                                                                                                                             
  - All notebooks 2.07–2.15: --model chemprop → --model chemeleon
  - scripts/: adds train_xgboost.sh, train_chemeleon.sh, combine.sh, exploration.sh for running full pipelines with dependency ordering  
  and per-job logging   